### PR TITLE
Add caching for fonts

### DIFF
--- a/examples/Bin.re
+++ b/examples/Bin.re
@@ -8,12 +8,17 @@ let init = app => {
 
   let ui = UI.create();
 
+  let textHeaderStyle = Style.make(~backgroundColor=Colors.black, ~color=Colors.white, ~fontFamily="Roboto-Regular.ttf", ~fontSize=24, ());
+
+  let smallerTextStyle = Style.make(~backgroundColor=Colors.black, ~color=Colors.white, ~fontFamily="Roboto-Regular.ttf", ~fontSize=12, ());
+
   Window.setRenderCallback(w, () => {
     UI.render(ui,
         <view style=(Style.make(~width=100, ~height=100, ~backgroundColor=Colors.blue, ()))>
             <view style=(Style.make(~width=10, ~height=10, ~backgroundColor=Colors.red, ())) />
             <image src="outrun-logo.png" style=(Style.make(~width=128, ~height=64, ())) />
-            <text style=(Style.make(~backgroundColor=Colors.black, ~color=Colors.white, ()))>"Hellop Worldq!"</text>
+            <text style=(textHeaderStyle)>"Hello World!"</text>
+            <text style=(smallerTextStyle)>"Welcome to revery"</text>
             <view style=(Style.make(~width=25, ~height=25, ~backgroundColor=Colors.green, ())) />
         </view>);
   });

--- a/src/UI/FontCache.re
+++ b/src/UI/FontCache.re
@@ -5,7 +5,7 @@ type t = Hashtbl.t(fontInfo, Fontkit.fk_face);
 let _cache: t = Hashtbl.create(100);
 
 let load = (fontName: string, size: int) => {
-    switch (Hashtbl.find_opt(_cache, (fontName, size))) {
+    let ret: Fontkit.fk_face = switch (Hashtbl.find_opt(_cache, (fontName, size))) {
     | Some(fk) => fk
     | None => 
         print_endline ("Loading cached font: " ++ fontName);
@@ -13,4 +13,5 @@ let load = (fontName: string, size: int) => {
         Hashtbl.add(_cache, (fontName, size), fk);
         fk
     }
+    ret
 }

--- a/src/UI/FontCache.re
+++ b/src/UI/FontCache.re
@@ -7,11 +7,10 @@ let _cache: t = Hashtbl.create(100);
 let load = (fontName: string, size: int) => {
     let ret: Fontkit.fk_face = switch (Hashtbl.find_opt(_cache, (fontName, size))) {
     | Some(fk) => fk
-    | None => 
-        print_endline ("Loading cached font: " ++ fontName);
+    | None =>
         let fk = Fontkit.load(fontName, size)
         Hashtbl.add(_cache, (fontName, size), fk);
         fk
     }
     ret
-}
+};

--- a/src/UI/FontCache.re
+++ b/src/UI/FontCache.re
@@ -1,0 +1,16 @@
+
+type fontInfo = (string, int);
+type t = Hashtbl.t(fontInfo, Fontkit.fk_face);
+
+let _cache: t = Hashtbl.create(100);
+
+let load = (fontName: string, size: int) => {
+    switch (Hashtbl.find_opt(_cache, (fontName, size))) {
+    | Some(fk) => fk
+    | None => 
+        print_endline ("Loading cached font: " ++ fontName);
+        let fk = Fontkit.load(fontName, size)
+        Hashtbl.add(_cache, (fontName, size), fk);
+        fk
+    }
+}

--- a/src/UI/Style.re
+++ b/src/UI/Style.re
@@ -2,6 +2,8 @@ open Layout;
 
 open Revery_Core;
 
+type fontFamily = string;
+
 type t = {
     backgroundColor: Color.t,
     color: Color.t,
@@ -12,6 +14,8 @@ type t = {
     bottom: int,
     left: int,
     right: int,
+    fontFamily: fontFamily,
+    fontSize: int,
 };
 
 let make = (
@@ -24,6 +28,8 @@ let make = (
     ~bottom=Encoding.cssUndefined,
     ~left=Encoding.cssUndefined,
     ~right=Encoding.cssUndefined,
+    ~fontFamily="",
+    ~fontSize=Encoding.cssUndefined,
     _unit: unit
 ) => {
 
@@ -37,6 +43,8 @@ let make = (
         bottom,
         left,
         right,
+        fontFamily,
+        fontSize,
     };
 
     ret;

--- a/src/UI/TextNode.re
+++ b/src/UI/TextNode.re
@@ -29,9 +29,10 @@ class textNode (name: string, text: string) = {
         Mat4.ortho(projection, 0.0, 800.0, 600.0, 0.0, -0.01, -100.0);
         Shaders.CompiledShader.setUniformMatrix4fv(textureShader, "uProjection", projection);
 
+        let style = _super#getStyle();
+        let font = FontCache.load(style.fontFamily, style.fontSize);
         let dimensions = _super#measurements();
-
-        let color = _super#getStyle().color;
+        let color = style.color;
 
         Shaders.CompiledShader.setUniform3fv(textureShader, "uColor", Color.toVec3(color));
 

--- a/src/UI/TextNode.re
+++ b/src/UI/TextNode.re
@@ -14,7 +14,7 @@ class textNode (name: string, text: string) = {
 
     val quad = Geometry.Cube.create();
     val textureShader = FontShader.create();
-    val font = FontCache.load("Roboto-Regular.ttf", 24);
+    val font = Fontkit.load("Roboto-Regular.ttf", 24);
 
     inherit (class viewNode)(name) as _super;
             

--- a/src/UI/TextNode.re
+++ b/src/UI/TextNode.re
@@ -5,19 +5,16 @@ module Geometry = Revery_Geometry;
 module Layout = Layout;
 module LayoutTypes = Layout.LayoutTypes;
 
-open Fontkit;
-
 open Revery_Core;
 
 open ViewNode;
-
 
 class textNode (name: string, text: string) = {
     as _this;
 
     val quad = Geometry.Cube.create();
     val textureShader = FontShader.create();
-    val font = Fontkit.load("Roboto-Regular.ttf", 24);
+    val font = FontCache.load("Roboto-Regular.ttf", 24);
 
     inherit (class viewNode)(name) as _super;
             

--- a/src/UI/TextNode.re
+++ b/src/UI/TextNode.re
@@ -5,6 +5,7 @@ module Geometry = Revery_Geometry;
 module Layout = Layout;
 module LayoutTypes = Layout.LayoutTypes;
 
+open Fontkit;
 open Revery_Core;
 
 open ViewNode;
@@ -14,7 +15,7 @@ class textNode (name: string, text: string) = {
 
     val quad = Geometry.Cube.create();
     val textureShader = FontShader.create();
-    val font = Fontkit.load("Roboto-Regular.ttf", 24);
+    val font = FontCache.load("Roboto-Regular.ttf", 24);
 
     inherit (class viewNode)(name) as _super;
             
@@ -35,7 +36,7 @@ class textNode (name: string, text: string) = {
         Shaders.CompiledShader.setUniform3fv(textureShader, "uColor", Color.toVec3(color));
 
         let render = (s: Fontkit.fk_shape, x: float, y: float) => {
-            let glyph = FontRenderer.getGlyph(font, s.codepoint);
+            let glyph: fk_glyph = FontRenderer.getGlyph(font, s.codepoint);
 
             let {width, height, bearingX, bearingY, advance, _} = glyph;
 


### PR DESCRIPTION
__Issue:__ Previous, we were loading fonts every frame. This is already expensive since we load them both in `harfbuzz` and `freetype`.

__Fix:__ Cache the loaded fonts so we don't keep reloading them.