### PR TITLE
Bugfix: Backspace doesn't totally clear input box

### DIFF
--- a/esy.json
+++ b/esy.json
@@ -17,7 +17,7 @@
     "reason-fontkit": "*",
     "reason-glfw": "*",
     "reason-gl-matrix": "^0.2.0",
-    "reason-reactify": "^1.0.0",
+    "reason-reactify": "^1.0.1",
     "@opam/lwt": "^4.0.0",
     "@opam/lwt_ppx": "^1.1.0",
     "@opam/js_of_ocaml": "*",


### PR DESCRIPTION
__Issue:__ The backspace key doesn't clear the final character.

Repro:
- Run `AutoComplete.exe`
- Press `a`
- Press `backspace`

Expected: Input should be clear
Actual: `a` is still hanging around

__Defect:__ This was a bug in `reason-reactify` - not properly comparing primitives in this case. That resulted in `updateInstance` not being called in our reconciler on the clear.

__Fix:__ This was fixed in bryphe/reason-reactify#22, and this change just pulls in a newer version.