### PR TITLE
Performance: Fix some low-hanging fruit

### DIFF
--- a/src/Core/App.re
+++ b/src/Core/App.re
@@ -60,8 +60,14 @@ let startWithState: startFunc('s, 'a) = (initialState: 's, reducer: reducer('s, 
         if (appInstance.needsRender) {
             Performance.bench("renderWindows", () => {
                 List.iter((w) => Window.render(w), getWindows(appInstance));
-                appInstance.needsRender = false;
+                appInstance.needsRender = List.fold_left((prev, w) => {
+                    prev || Window.isDirty(w)
+                }, false, getWindows(appInstance));
+
+                
             });
+
+            
         } else {
             Unix.sleepf(1. /. 100.);
         };

--- a/src/Core/App.re
+++ b/src/Core/App.re
@@ -58,8 +58,10 @@ let startWithState: startFunc('s, 'a) = (initialState: 's, reducer: reducer('s, 
     let appLoop = (_t: float) => {
         glfwPollEvents();
         if (appInstance.needsRender) {
-            List.iter((w) => Window.render(w), getWindows(appInstance));
-            appInstance.needsRender = false;
+            Performance.bench("renderWindows", () => {
+                List.iter((w) => Window.render(w), getWindows(appInstance));
+                appInstance.needsRender = false;
+            });
         } else {
             Unix.sleepf(1. /. 100.);
         };

--- a/src/Core/App.re
+++ b/src/Core/App.re
@@ -3,78 +3,78 @@ open Reglfw.Glfw;
 type reducer('s, 'a) = ('s, 'a) => 's;
 
 type t('s, 'a) = {
-    reducer: reducer('s, 'a),
-    mutable state: 's,
-    mutable windows: list(Window.t),
-    mutable needsRender: bool
+  reducer: reducer('s, 'a),
+  mutable state: 's,
+  mutable windows: list(Window.t),
+  mutable needsRender: bool,
 };
 
 /* If no state is specified, just use unit! */
 let defaultState = ();
 
 /* If no reducer is specified, just pass through state */
-let defaultReducer: reducer(unit, unit) = (_s, _a) => ()
+let defaultReducer: reducer(unit, unit) = (_s, _a) => ();
 
-type appInitFunc('s, 'a) = (t('s, 'a)) => unit;
+type appInitFunc('s, 'a) = t('s, 'a) => unit;
 
 type startFunc('s, 'a) = ('s, reducer('s, 'a), appInitFunc('s, 'a)) => unit;
 
-let getWindows = (app: t('s, 'a)) => {
-    app.windows
-};
+let getWindows = (app: t('s, 'a)) => app.windows;
 
-let getState = (app: t('s, 'a)) => {
-    app.state
-};
+let getState = (app: t('s, 'a)) => app.state;
 
-let quit = (code: int) => {
-    exit(code);
-};
+let quit = (code: int) => exit(code);
 
 let dispatch = (app: t('s, 'a), action: 'a) => {
-    let newState = app.reducer(app.state, action);
-    app.state = newState;
-    app.needsRender = true;
+  let newState = app.reducer(app.state, action);
+  app.state = newState;
+  app.needsRender = true;
 };
 
-let createWindow = (~createOptions=Window.defaultCreateOptions, app: t('s, 'a), windowName) => {
-    let w = Window.create(windowName, createOptions);
-    /* Window.render(w) */
-    app.windows = [w, ...app.windows];
-    w;
+let createWindow =
+    (~createOptions=Window.defaultCreateOptions, app: t('s, 'a), windowName) => {
+  let w = Window.create(windowName, createOptions);
+  /* Window.render(w) */
+  app.windows = [w, ...app.windows];
+  w;
 };
 
-let startWithState: startFunc('s, 'a) = (initialState: 's, reducer: reducer('s, 'a), initFunc: appInitFunc('s, 'a)) => {
+let startWithState: startFunc('s, 'a) =
+  (
+    initialState: 's,
+    reducer: reducer('s, 'a),
+    initFunc: appInitFunc('s, 'a),
+  ) => {
     let appInstance: t('s, 'a) = {
-        reducer: reducer,
-        state: initialState,
-        windows: [],
-        needsRender: true,
+      reducer,
+      state: initialState,
+      windows: [],
+      needsRender: true,
     };
 
     let _ = glfwInit();
     let _ = initFunc(appInstance);
 
     let appLoop = (_t: float) => {
-        glfwPollEvents();
-        if (appInstance.needsRender) {
-            Performance.bench("renderWindows", () => {
-                List.iter((w) => Window.render(w), getWindows(appInstance));
-                appInstance.needsRender = List.fold_left((prev, w) => {
-                    prev || Window.isDirty(w)
-                }, false, getWindows(appInstance));
-
-                
-            });
-
-            
-        } else {
-            Unix.sleepf(1. /. 100.);
-        };
-        false
+      glfwPollEvents();
+      if (appInstance.needsRender) {
+        Performance.bench("renderWindows", () => {
+          List.iter(w => Window.render(w), getWindows(appInstance));
+          appInstance.needsRender =
+            List.fold_left(
+              (prev, w) => prev || Window.isDirty(w),
+              false,
+              getWindows(appInstance),
+            );
+        });
+      } else {
+        Unix.sleepf(1. /. 100.);
+      };
+      false;
     };
 
     glfwRenderLoop(appLoop);
-}
+  };
 
-let start = (initFunc: appInitFunc(unit, unit)) => startWithState(defaultState, defaultReducer, initFunc);
+let start = (initFunc: appInitFunc(unit, unit)) =>
+  startWithState(defaultState, defaultReducer, initFunc);

--- a/src/Core/Performance.re
+++ b/src/Core/Performance.re
@@ -4,18 +4,24 @@ type performanceFunction = unit => unit;
 
 let nestingLevel = ref(0);
 
-let bench = (name, f) => {
-  nestingLevel := nestingLevel^ + 1;
-  let startTime = glfwGetTime();
-  f();
-  let endTime = glfwGetTime();
-  print_endline(
-    String.make(nestingLevel^, '-')
-    ++ "[PERF: "
-    ++ name
-    ++ "]: "
-    ++ string_of_float((endTime -. startTime) /. 1000.)
-    ++ "ms",
-  );
-  nestingLevel := nestingLevel^ - 1;
-};
+let bench =
+  switch (Sys.getenv_opt("REVERY_DEBUG")) {
+  | None => ((_name, f) => f())
+  | Some(_) => (
+      (name, f) => {
+        nestingLevel := nestingLevel^ + 1;
+        let startTime = glfwGetTime();
+        f();
+        let endTime = glfwGetTime();
+        print_endline(
+          String.make(nestingLevel^, '-')
+          ++ "[PERF: "
+          ++ name
+          ++ "]: "
+          ++ string_of_float((endTime -. startTime) /. 1000.)
+          ++ "ms",
+        );
+        nestingLevel := nestingLevel^ - 1;
+      }
+    )
+  };

--- a/src/Core/Performance.re
+++ b/src/Core/Performance.re
@@ -1,0 +1,8 @@
+type performanceFunction =  unit => unit;
+
+let bench = (name, f) => {
+    let startTime = Unix.gettimeofday();
+    f();
+    let endTime = Unix.gettimeofday();
+    print_endline("[PERF: " ++ name ++ "]: " ++ string_of_float((endTime -. startTime) /. 1000.) ++ "ms");
+};

--- a/src/Core/Performance.re
+++ b/src/Core/Performance.re
@@ -1,8 +1,13 @@
 type performanceFunction =  unit => unit;
 
+let nestingLevel = ref(0);
+
 let bench = (name, f) => {
+
+    nestingLevel := nestingLevel^ + 1;
     let startTime = Unix.gettimeofday();
     f();
     let endTime = Unix.gettimeofday();
-    print_endline("[PERF: " ++ name ++ "]: " ++ string_of_float((endTime -. startTime) /. 1000.) ++ "ms");
+    print_endline(String.make(nestingLevel^, '-') ++ "[PERF: " ++ name ++ "]: " ++ string_of_float((endTime -. startTime) /. 1000.) ++ "ms");
+    nestingLevel := nestingLevel^ - 1;
 };

--- a/src/Core/Performance.re
+++ b/src/Core/Performance.re
@@ -1,3 +1,5 @@
+open Reglfw.Glfw;
+
 type performanceFunction =  unit => unit;
 
 let nestingLevel = ref(0);
@@ -5,9 +7,9 @@ let nestingLevel = ref(0);
 let bench = (name, f) => {
 
     nestingLevel := nestingLevel^ + 1;
-    let startTime = Unix.gettimeofday();
+    let startTime = glfwGetTime();
     f();
-    let endTime = Unix.gettimeofday();
+    let endTime = glfwGetTime();
     print_endline(String.make(nestingLevel^, '-') ++ "[PERF: " ++ name ++ "]: " ++ string_of_float((endTime -. startTime) /. 1000.) ++ "ms");
     nestingLevel := nestingLevel^ - 1;
 };

--- a/src/Core/Performance.re
+++ b/src/Core/Performance.re
@@ -1,15 +1,21 @@
 open Reglfw.Glfw;
 
-type performanceFunction =  unit => unit;
+type performanceFunction = unit => unit;
 
 let nestingLevel = ref(0);
 
 let bench = (name, f) => {
-
-    nestingLevel := nestingLevel^ + 1;
-    let startTime = glfwGetTime();
-    f();
-    let endTime = glfwGetTime();
-    print_endline(String.make(nestingLevel^, '-') ++ "[PERF: " ++ name ++ "]: " ++ string_of_float((endTime -. startTime) /. 1000.) ++ "ms");
-    nestingLevel := nestingLevel^ - 1;
+  nestingLevel := nestingLevel^ + 1;
+  let startTime = glfwGetTime();
+  f();
+  let endTime = glfwGetTime();
+  print_endline(
+    String.make(nestingLevel^, '-')
+    ++ "[PERF: "
+    ++ name
+    ++ "]: "
+    ++ string_of_float((endTime -. startTime) /. 1000.)
+    ++ "ms",
+  );
+  nestingLevel := nestingLevel^ - 1;
 };

--- a/src/Core/Revery_Core.re
+++ b/src/Core/Revery_Core.re
@@ -7,3 +7,34 @@ let module Time = Time;
 let module Monitor = Monitor;
 
 let module Event = Reactify.Event;
+
+module Performance {
+    type performanceFunction =  unit => unit;
+
+    let bench = (name, f) => {
+        let startTime = Unix.gettimeofday();
+        f();
+        let endTime = Unix.gettimeofday();
+        print_endline("[PERF: " ++ name ++ "]: " ++ string_of_float((endTime -. startTime) /. 1000.) ++ "ms");
+    };
+}
+
+module Lazy {
+    type innerFunc('a) = unit => 'a;
+
+    let make = (f: innerFunc('a)): innerFunc('a) => {
+        let v: ref(option('a)) = ref(None);
+
+        let ret = () => {
+            switch(v^) {
+            | Some(x) => x
+            | None => {
+                let out = f();
+                v := Some(out);
+                out
+                }
+            };
+        };
+        ret;
+    };
+}

--- a/src/Core/Revery_Core.re
+++ b/src/Core/Revery_Core.re
@@ -8,16 +8,7 @@ let module Monitor = Monitor;
 
 let module Event = Reactify.Event;
 
-module Performance {
-    type performanceFunction =  unit => unit;
-
-    let bench = (name, f) => {
-        let startTime = Unix.gettimeofday();
-        f();
-        let endTime = Unix.gettimeofday();
-        print_endline("[PERF: " ++ name ++ "]: " ++ string_of_float((endTime -. startTime) /. 1000.) ++ "ms");
-    };
-}
+module Performance = Performance;
 
 module Lazy {
     type innerFunc('a) = unit => 'a;

--- a/src/Core/Revery_Core.re
+++ b/src/Core/Revery_Core.re
@@ -1,31 +1,29 @@
-let module Color = Color;
-let module Colors = Colors;
+module Color = Color;
+module Colors = Colors;
 
-let module Window = Window;
-let module App = App;
-let module Time = Time;
-let module Monitor = Monitor;
+module Window = Window;
+module App = App;
+module Time = Time;
+module Monitor = Monitor;
 
-let module Event = Reactify.Event;
+module Event = Reactify.Event;
 
 module Performance = Performance;
 
-module Lazy {
-    type innerFunc('a) = unit => 'a;
+module Lazy = {
+  type innerFunc('a) = unit => 'a;
 
-    let make = (f: innerFunc('a)): innerFunc('a) => {
-        let v: ref(option('a)) = ref(None);
+  let make = (f: innerFunc('a)): innerFunc('a) => {
+    let v: ref(option('a)) = ref(None);
 
-        let ret = () => {
-            switch(v^) {
-            | Some(x) => x
-            | None => {
-                let out = f();
-                v := Some(out);
-                out
-                }
-            };
-        };
-        ret;
-    };
-}
+    let ret = () =>
+      switch (v^) {
+      | Some(x) => x
+      | None =>
+        let out = f();
+        v := Some(out);
+        out;
+      };
+    ret;
+  };
+};

--- a/src/Core/Window.re
+++ b/src/Core/Window.re
@@ -42,6 +42,7 @@ type windowCreateOptions = {
     width: int,
     height: int,
     backgroundColor: Color.t,
+    vsync: bool,
 };
 
 let defaultCreateOptions = {
@@ -52,6 +53,7 @@ let defaultCreateOptions = {
     width: 800,
     height: 600,
     backgroundColor: Colors.cornflowerBlue
+    vsync: false,
 };
 
 let isDirty = (w: t) => {
@@ -117,6 +119,13 @@ let create = (name: string, options: windowCreateOptions) => {
     glfwWindowHint(GLFW_VISIBLE, options.visible);
     glfwWindowHint(GLFW_MAXIMIZED, options.maximized);
     glfwWindowHint(GLFW_DECORATED, options.decorated);
+
+    let swap = switch(options.vsync) {
+    | true => 1
+    | false => 0
+    };
+
+    glfwSwapInterval(swap);
 
     let w = glfwCreateWindow(options.width, options.height, name);
     glfwMakeContextCurrent(w);

--- a/src/Core/Window.re
+++ b/src/Core/Window.re
@@ -70,7 +70,6 @@ let setSize = (w: t, width: int, height: int) =>
     if (w.isRendering) {
       w.requestedWidth = Some(width);
       w.requestedHeight = Some(height);
-      print_endline("Queing render");
     } else {
       glfwSetWindowSize(w.glfwWindow, width, height);
       w.width = width;

--- a/src/Core/Window.re
+++ b/src/Core/Window.re
@@ -52,8 +52,8 @@ let defaultCreateOptions = {
     decorated: true,
     width: 800,
     height: 600,
-    backgroundColor: Colors.cornflowerBlue
-    vsync: false,
+    backgroundColor: Colors.cornflowerBlue,
+    vsync: true
 };
 
 let isDirty = (w: t) => {
@@ -120,12 +120,10 @@ let create = (name: string, options: windowCreateOptions) => {
     glfwWindowHint(GLFW_MAXIMIZED, options.maximized);
     glfwWindowHint(GLFW_DECORATED, options.decorated);
 
-    let swap = switch(options.vsync) {
-    | true => 1
-    | false => 0
+    switch(options.vsync) {
+    | false => glfwSwapInterval(0);
+    | _ => ()
     };
-
-    glfwSwapInterval(swap);
 
     let w = glfwCreateWindow(options.width, options.height, name);
     glfwMakeContextCurrent(w);

--- a/src/Core/Window.re
+++ b/src/Core/Window.re
@@ -3,246 +3,240 @@ open Reglfw.Glfw;
 module Event = Reactify.Event;
 
 type keyPressEvent = {
-    codepoint: int,
-    character: string
+  codepoint: int,
+  character: string,
 };
 
 type keyEvent = {
-    key: Key.t,
-    scancode: int,
-    altKey: bool,
-    ctrlKey: bool,
-    shiftKey: bool,
-    superKey: bool,
-    isRepeat: bool,
+  key: Key.t,
+  scancode: int,
+  altKey: bool,
+  ctrlKey: bool,
+  shiftKey: bool,
+  superKey: bool,
+  isRepeat: bool,
 };
 
 type windowRenderCallback = unit => unit;
 type t = {
-    mutable backgroundColor: Color.t,
-    glfwWindow: window,
-    render: ref(option(windowRenderCallback)),
-    mutable width: int,
-    mutable height: int,
-
-    mutable isRendering: bool,
-    mutable requestedWidth: option(int),
-    mutable requestedHeight: option(int),
-
-    onKeyPress: Event.t(keyPressEvent),
-    onKeyDown: Event.t(keyEvent),
-    onKeyUp: Event.t(keyEvent),
+  mutable backgroundColor: Color.t,
+  glfwWindow: window,
+  render: ref(option(windowRenderCallback)),
+  mutable width: int,
+  mutable height: int,
+  mutable isRendering: bool,
+  mutable requestedWidth: option(int),
+  mutable requestedHeight: option(int),
+  onKeyPress: Event.t(keyPressEvent),
+  onKeyDown: Event.t(keyEvent),
+  onKeyUp: Event.t(keyEvent),
 };
 
 type windowCreateOptions = {
-    resizable: bool,
-    visible: bool,
-    maximized: bool,
-    decorated: bool,
-    width: int,
-    height: int,
-    backgroundColor: Color.t,
-    vsync: bool,
+  resizable: bool,
+  visible: bool,
+  maximized: bool,
+  decorated: bool,
+  width: int,
+  height: int,
+  backgroundColor: Color.t,
+  vsync: bool,
 };
 
 let defaultCreateOptions = {
-    resizable: true,
-    visible: true,
-    maximized: false,
-    decorated: true,
-    width: 800,
-    height: 600,
-    backgroundColor: Colors.cornflowerBlue,
-    vsync: true
+  resizable: true,
+  visible: true,
+  maximized: false,
+  decorated: true,
+  width: 800,
+  height: 600,
+  backgroundColor: Colors.cornflowerBlue,
+  vsync: true,
 };
 
-let isDirty = (w: t) => {
-    switch ((w.requestedWidth, w.requestedHeight)) {
-    | (Some(_), _) => true
-    | (_, Some(_)) => true
-    | _ => false
+let isDirty = (w: t) =>
+  switch (w.requestedWidth, w.requestedHeight) {
+  | (Some(_), _) => true
+  | (_, Some(_)) => true
+  | _ => false
+  };
+
+let setSize = (w: t, width: int, height: int) =>
+  if (width != w.width || height != w.height) {
+    /*
+     *  Don't resize in the middle of a render -
+     *  we'll queue up the render operation for next time.
+     */
+    if (w.isRendering) {
+      w.requestedWidth = Some(width);
+      w.requestedHeight = Some(height);
+      print_endline("Queing render");
+    } else {
+      glfwSetWindowSize(w.glfwWindow, width, height);
+      w.width = width;
+      w.height = height;
+      w.requestedWidth = None;
+      w.requestedHeight = None;
     };
-};
+  };
 
-let setSize = (w: t, width: int, height: int) => {
-    if (width != w.width || height != w.height) {
-        /*
-         *  Don't resize in the middle of a render -
-         *  we'll queue up the render operation for next time.
-         */
-        if (w.isRendering) {
-            w.requestedWidth = Some(width);
-            w.requestedHeight = Some(height);
-            print_endline ("Queing render");
-        } else {
-            glfwSetWindowSize(w.glfwWindow, width, height);
-            w.width = width;
-            w.height = height;
-            w.requestedWidth = None;
-            w.requestedHeight = None;
-        }
-    }
-};
-
-let _resizeIfNecessary = (w: t) => {
-    switch ((w.requestedWidth, w.requestedHeight)) {
-    | (Some(width), Some(height)) => setSize(w, width, height)
-    | _ => ()
-    }
-};
+let _resizeIfNecessary = (w: t) =>
+  switch (w.requestedWidth, w.requestedHeight) {
+  | (Some(width), Some(height)) => setSize(w, width, height)
+  | _ => ()
+  };
 
 let render = (w: t) => {
-    _resizeIfNecessary(w);
-    w.isRendering = true;
-    glfwMakeContextCurrent(w.glfwWindow);
+  _resizeIfNecessary(w);
+  w.isRendering = true;
+  glfwMakeContextCurrent(w.glfwWindow);
 
-    glViewport(0, 0, w.width, w.height);
-    glClearDepth(1.0);
-    glEnable(GL_DEPTH_TEST);
-    glDepthFunc(GL_LEQUAL);
+  glViewport(0, 0, w.width, w.height);
+  glClearDepth(1.0);
+  glEnable(GL_DEPTH_TEST);
+  glDepthFunc(GL_LEQUAL);
 
-    let color = w.backgroundColor;
-    glClearColor(color.r, color.g, color.b, color.a);
+  let color = w.backgroundColor;
+  glClearColor(color.r, color.g, color.b, color.a);
 
-    switch(w.render^) {
-    | None => ()
-    | Some(r) => r();
-    };
+  switch (w.render^) {
+  | None => ()
+  | Some(r) => r()
+  };
 
-    glfwSwapBuffers(w.glfwWindow);
-    w.isRendering = false;
+  glfwSwapBuffers(w.glfwWindow);
+  w.isRendering = false;
 };
 
 let create = (name: string, options: windowCreateOptions) => {
-    glfwDefaultWindowHints();
-    glfwWindowHint(GLFW_RESIZABLE, options.resizable);
-    glfwWindowHint(GLFW_VISIBLE, options.visible);
-    glfwWindowHint(GLFW_MAXIMIZED, options.maximized);
-    glfwWindowHint(GLFW_DECORATED, options.decorated);
+  glfwDefaultWindowHints();
+  glfwWindowHint(GLFW_RESIZABLE, options.resizable);
+  glfwWindowHint(GLFW_VISIBLE, options.visible);
+  glfwWindowHint(GLFW_MAXIMIZED, options.maximized);
+  glfwWindowHint(GLFW_DECORATED, options.decorated);
 
-    switch(options.vsync) {
-    | false => glfwSwapInterval(0);
-    | _ => ()
-    };
+  switch (options.vsync) {
+  | false => glfwSwapInterval(0)
+  | _ => ()
+  };
 
-    let w = glfwCreateWindow(options.width, options.height, name);
-    glfwMakeContextCurrent(w);
+  let w = glfwCreateWindow(options.width, options.height, name);
+  glfwMakeContextCurrent(w);
 
-    let ret: t = {
-        backgroundColor: options.backgroundColor,
-        glfwWindow: w,
-        render: ref(None),
-        width: options.width,
-        height: options.height,
+  let ret: t = {
+    backgroundColor: options.backgroundColor,
+    glfwWindow: w,
+    render: ref(None),
+    width: options.width,
+    height: options.height,
 
-        isRendering: false,
-        requestedWidth: None,
-        requestedHeight: None,
+    isRendering: false,
+    requestedWidth: None,
+    requestedHeight: None,
 
-        onKeyPress: Event.create(),
-        onKeyDown: Event.create(),
-        onKeyUp: Event.create(),
-    };
+    onKeyPress: Event.create(),
+    onKeyDown: Event.create(),
+    onKeyUp: Event.create(),
+  };
 
-    glfwSetFramebufferSizeCallback(w, (_w, width, height) => {
-        ret.width = width;
-        ret.height = height;
-        render(ret);
-    });
+  glfwSetFramebufferSizeCallback(
+    w,
+    (_w, width, height) => {
+      ret.width = width;
+      ret.height = height;
+      render(ret);
+    },
+  );
 
-    glfwSetCharCallback(w, (_, codepoint) => {
-       let uchar = Uchar.of_int(codepoint);
-       let character = switch (Uchar.is_char(uchar)) {
-       | true => String.make(1, Uchar.to_char(uchar))
-       | _ => ""
-       };
-      let keyPressEvent: keyPressEvent = {
-            codepoint,
-            character,
-      };
-      Event.dispatch(ret.onKeyPress, keyPressEvent);
-    });
-
-    glfwSetKeyCallback(w, (_w, key, scancode, buttonState, m) => {
-        let evt: keyEvent = {
-            key,
-            scancode,
-            ctrlKey: Modifier.isControlPressed(m),
-            shiftKey: Modifier.isShiftPressed(m),
-            altKey: Modifier.isAltPressed(m),
-            superKey: Modifier.isSuperPressed(m),
-            isRepeat: buttonState == GLFW_REPEAT,
+  glfwSetCharCallback(
+    w,
+    (_, codepoint) => {
+      let uchar = Uchar.of_int(codepoint);
+      let character =
+        switch (Uchar.is_char(uchar)) {
+        | true => String.make(1, Uchar.to_char(uchar))
+        | _ => ""
         };
-
-        switch (buttonState) {
-        | GLFW_PRESS => Event.dispatch(ret.onKeyDown, evt)
-        | GLFW_REPEAT => Event.dispatch(ret.onKeyDown, evt)
-        | GLFW_RELEASE => Event.dispatch(ret.onKeyUp, evt)
-        }
-    });
-
-    glfwSetCharCallback(w, (_, codepoint) => {
-       let uchar = Uchar.of_int(codepoint);
-       let character = switch (Uchar.is_char(uchar)) {
-       | true => String.make(1, Uchar.to_char(uchar))
-       | _ => ""
-       };
-      let keyPressEvent: keyPressEvent = {
-            codepoint,
-            character,
-      };
+      let keyPressEvent: keyPressEvent = {codepoint, character};
       Event.dispatch(ret.onKeyPress, keyPressEvent);
-    });
+    },
+  );
 
-    glfwSetKeyCallback(w, (_w, key, scancode, buttonState, m) => {
-        let evt: keyEvent = {
-            key,
-            scancode,
-            ctrlKey: Modifier.isControlPressed(m),
-            shiftKey: Modifier.isShiftPressed(m),
-            altKey: Modifier.isAltPressed(m),
-            superKey: Modifier.isSuperPressed(m),
-            isRepeat: buttonState == GLFW_REPEAT,
+  glfwSetKeyCallback(
+    w,
+    (_w, key, scancode, buttonState, m) => {
+      let evt: keyEvent = {
+        key,
+        scancode,
+        ctrlKey: Modifier.isControlPressed(m),
+        shiftKey: Modifier.isShiftPressed(m),
+        altKey: Modifier.isAltPressed(m),
+        superKey: Modifier.isSuperPressed(m),
+        isRepeat: buttonState == GLFW_REPEAT,
+      };
+
+      switch (buttonState) {
+      | GLFW_PRESS => Event.dispatch(ret.onKeyDown, evt)
+      | GLFW_REPEAT => Event.dispatch(ret.onKeyDown, evt)
+      | GLFW_RELEASE => Event.dispatch(ret.onKeyUp, evt)
+      };
+    },
+  );
+
+  glfwSetCharCallback(
+    w,
+    (_, codepoint) => {
+      let uchar = Uchar.of_int(codepoint);
+      let character =
+        switch (Uchar.is_char(uchar)) {
+        | true => String.make(1, Uchar.to_char(uchar))
+        | _ => ""
         };
+      let keyPressEvent: keyPressEvent = {codepoint, character};
+      Event.dispatch(ret.onKeyPress, keyPressEvent);
+    },
+  );
 
-        switch (buttonState) {
-        | GLFW_PRESS => Event.dispatch(ret.onKeyDown, evt)
-        | GLFW_REPEAT => Event.dispatch(ret.onKeyDown, evt)
-        | GLFW_RELEASE => Event.dispatch(ret.onKeyUp, evt)
-        }
-    });
-    ret;
+  glfwSetKeyCallback(
+    w,
+    (_w, key, scancode, buttonState, m) => {
+      let evt: keyEvent = {
+        key,
+        scancode,
+        ctrlKey: Modifier.isControlPressed(m),
+        shiftKey: Modifier.isShiftPressed(m),
+        altKey: Modifier.isAltPressed(m),
+        superKey: Modifier.isSuperPressed(m),
+        isRepeat: buttonState == GLFW_REPEAT,
+      };
+
+      switch (buttonState) {
+      | GLFW_PRESS => Event.dispatch(ret.onKeyDown, evt)
+      | GLFW_REPEAT => Event.dispatch(ret.onKeyDown, evt)
+      | GLFW_RELEASE => Event.dispatch(ret.onKeyUp, evt)
+      };
+    },
+  );
+  ret;
 };
 
-let setBackgroundColor = (w: t, color: Color.t) => {
-    w.backgroundColor = color;
-}
+let setBackgroundColor = (w: t, color: Color.t) => w.backgroundColor = color;
 
-let setPos = (w: t, x: int, y: int) => {
-    glfwSetWindowPos(w.glfwWindow, x, y);
-};
+let setPos = (w: t, x: int, y: int) => glfwSetWindowPos(w.glfwWindow, x, y);
 
-let show = (w) => {
-    glfwShowWindow(w.glfwWindow);
-};
+let show = w => glfwShowWindow(w.glfwWindow);
 
-let hide = (w) => {
-    glfwHideWindow(w.glfwWindow);
-};
+let hide = w => glfwHideWindow(w.glfwWindow);
 
 type windowSize = {
-    width: int,
-    height: int,
-}
+  width: int,
+  height: int,
+};
 
 let getSize = (w: t) => {
-    let r: windowSize = {
-        width: w.width,
-        height: w.height,
-    };
-    r
-}
-
-let setRenderCallback = (w: t, callback: windowRenderCallback) => {
-    w.render := Some(callback);
+  let r: windowSize = {width: w.width, height: w.height};
+  r;
 };
+
+let setRenderCallback = (w: t, callback: windowRenderCallback) =>
+  w.render := Some(callback);

--- a/src/UI/Assets.re
+++ b/src/UI/Assets.re
@@ -1,0 +1,14 @@
+/**
+ * Assets
+ * 
+ * Lazily initialized assets to be re-used across frames
+ */
+
+module Lazy = Revery_Core.Lazy;
+module Geometry = Revery_Geometry;
+
+let solidShader = Lazy.make(() => SolidShader.create());
+let fontShader = Lazy.make(() => FontShader.create());
+let textureShader = Lazy.make(() => TextureShader.create());
+
+let quad = Lazy.make(() => Geometry.Quad.create());

--- a/src/UI/ImageNode.re
+++ b/src/UI/ImageNode.re
@@ -13,8 +13,8 @@ open RenderPass;
 class imageNode (name: string, imagePath: string) = {
     as _this;
 
-    val _quad = Geometry.Cube.create();
-    val textureShader = TextureShader.create();
+    val _quad = Assets.quad();
+    val textureShader = Assets.textureShader();
     val texture = ImageRenderer.getTexture(imagePath);
 
     inherit (class node(renderPass))(name) as _super;

--- a/src/UI/Revery_UI.re
+++ b/src/UI/Revery_UI.re
@@ -3,6 +3,7 @@ open Reglm;
 module Shaders = Revery_Shaders;
 module Geometry = Revery_Geometry;
 module Window = Revery_Core.Window;
+module Performance = Revery_Core.Performance;
 
 module Layout = Layout;
 module LayoutTypes = Layout.LayoutTypes;
@@ -57,7 +58,10 @@ let _projection = Mat4.create();
 
 let render = (container: uiContainer, component: UiReact.component) => {
     let { rootNode, container, window, options } = container;
-    UiReact.updateContainer(container, component);
+
+    Performance.bench("updateContainer", () => {
+        UiReact.updateContainer(container, component);
+    });
 
     let size = switch (options.autoSize) {
     | false => {
@@ -83,5 +87,7 @@ let render = (container: uiContainer, component: UiReact.component) => {
     let renderPass = SolidPass(_projection);
 
     let m = Mat4.create();
+    Performance.bench("draw", () => {
     rootNode#draw(renderPass, 0, m);
+    });
 };

--- a/src/UI/Revery_UI.re
+++ b/src/UI/Revery_UI.re
@@ -63,12 +63,11 @@ let render = (container: uiContainer, component: UiReact.component) => {
         UiReact.updateContainer(container, component);
     });
 
-    let size = switch (options.autoSize) {
+    switch (options.autoSize) {
     | false => {
         let size = Window.getSize(window);
         rootNode#setStyle(Style.make(~position=LayoutTypes.Relative,~width=size.width, ~height=size.height, ()));
         layout(rootNode);
-        size
     }
     | true => {
         rootNode#setStyle(Style.make(()));
@@ -79,9 +78,10 @@ let render = (container: uiContainer, component: UiReact.component) => {
             height: measurements.height,
         };
         Window.setSize(window, size.width, size.height);
-        size
     }
     }
+
+    let size = Window.getSize(window);
 
     Mat4.ortho(_projection, 0.0, float_of_int(size.width), float_of_int(size.height), 0.0, -0.01, -100.0);
     let renderPass = SolidPass(_projection);

--- a/src/UI/Revery_UI.re
+++ b/src/UI/Revery_UI.re
@@ -11,83 +11,95 @@ module Style = Style;
 
 open RenderPass;
 
-class viewNode = ViewNode.viewNode;
-class textNode = TextNode.textNode;
-class imageNode = ImageNode.imageNode;
+class viewNode = class ViewNode.viewNode;
+class textNode = class TextNode.textNode;
+class imageNode = class ImageNode.imageNode;
 
 module UiReact = Reactify.Make(UiReconciler);
 
 open UiReconciler;
-let view = (~children, ~style=Style.defaultStyle, ()) => 
-    UiReact.primitiveComponent(View(style), ~children);
+let view = (~children, ~style=Style.defaultStyle, ()) =>
+  UiReact.primitiveComponent(View(style), ~children);
 
-let image = (~children, ~style=Style.defaultStyle, ~src="", ()) => 
-    UiReact.primitiveComponent(Image(style, src), ~children);
+let image = (~children, ~style=Style.defaultStyle, ~src="", ()) =>
+  UiReact.primitiveComponent(Image(style, src), ~children);
 
 let text = (~children: list(string), ~style=Style.defaultStyle, ()) =>
-    UiReact.primitiveComponent(Text(style, List.hd(children)), ~children=[]);
+  UiReact.primitiveComponent(Text(style, List.hd(children)), ~children=[]);
 
-type uiContainerOptions = {
-    autoSize: bool,
-};
+type uiContainerOptions = {autoSize: bool};
 
-let defaultUiContainerOptions: uiContainerOptions = {
-    autoSize: false,
-};
+let defaultUiContainerOptions: uiContainerOptions = {autoSize: false};
 
 type uiContainer = {
-    rootNode: viewNode,
-    container: UiReact.t,
-    window: Window.t,
-    options: uiContainerOptions,
+  rootNode: viewNode,
+  container: UiReact.t,
+  window: Window.t,
+  options: uiContainerOptions,
 };
 
 let create = (~createOptions=defaultUiContainerOptions, window: Window.t) => {
-     let rootNode = new viewNode ("root");
-     let container = UiReact.createContainer(rootNode);
-     let ret: uiContainer = { window, rootNode, container, options: createOptions };
-     ret;
+  let rootNode = (new viewNode)("root");
+  let container = UiReact.createContainer(rootNode);
+  let ret: uiContainer = {
+    window,
+    rootNode,
+    container,
+    options: createOptions,
+  };
+  ret;
 };
 
-let layout = (node) => {
-    let rootLayoutNode = node#toLayoutNode();
-    Layout.layoutNode(rootLayoutNode);
+let layout = node => {
+  let rootLayoutNode = node#toLayoutNode();
+  Layout.layoutNode(rootLayoutNode);
 };
 
 let _projection = Mat4.create();
 
 let render = (container: uiContainer, component: UiReact.component) => {
-    let { rootNode, container, window, options } = container;
+  let {rootNode, container, window, options} = container;
 
-    Performance.bench("updateContainer", () => {
-        UiReact.updateContainer(container, component);
-    });
+  Performance.bench("updateContainer", () =>
+    UiReact.updateContainer(container, component)
+  );
 
-    switch (options.autoSize) {
-    | false => {
-        let size = Window.getSize(window);
-        rootNode#setStyle(Style.make(~position=LayoutTypes.Relative,~width=size.width, ~height=size.height, ()));
-        layout(rootNode);
-    }
-    | true => {
-        rootNode#setStyle(Style.make(()));
-        layout(rootNode);
-        let measurements = rootNode#measurements();
-        let size: Window.windowSize = {
-            width: measurements.width,
-            height: measurements.height,
-        };
-        Window.setSize(window, size.width, size.height);
-    }
-    }
-
+  switch (options.autoSize) {
+  | false =>
     let size = Window.getSize(window);
+    rootNode#setStyle(
+      Style.make(
+        ~position=LayoutTypes.Relative,
+        ~width=size.width,
+        ~height=size.height,
+        (),
+      ),
+    );
+    layout(rootNode);
+  | true =>
+    rootNode#setStyle(Style.make());
+    layout(rootNode);
+    let measurements = rootNode#measurements();
+    let size: Window.windowSize = {
+      width: measurements.width,
+      height: measurements.height,
+    };
+    Window.setSize(window, size.width, size.height);
+  };
 
-    Mat4.ortho(_projection, 0.0, float_of_int(size.width), float_of_int(size.height), 0.0, -0.01, -100.0);
-    let renderPass = SolidPass(_projection);
+  let size = Window.getSize(window);
 
-    let m = Mat4.create();
-    Performance.bench("draw", () => {
-    rootNode#draw(renderPass, 0, m);
-    });
+  Mat4.ortho(
+    _projection,
+    0.0,
+    float_of_int(size.width),
+    float_of_int(size.height),
+    0.0,
+    -0.01,
+    -100.0,
+  );
+  let renderPass = SolidPass(_projection);
+
+  let m = Mat4.create();
+  Performance.bench("draw", () => rootNode#draw(renderPass, 0, m));
 };

--- a/src/UI/TextNode.re
+++ b/src/UI/TextNode.re
@@ -14,8 +14,8 @@ class textNode (name: string, text: string) = {
     as _this;
 
     val mutable text = text;
-    val quad = Geometry.Cube.create();
-    val textureShader = FontShader.create();
+    val quad = Assets.quad();
+    val textureShader = Assets.fontShader();
 
     inherit (class viewNode)(name) as _super;
             

--- a/src/UI/TextNode.re
+++ b/src/UI/TextNode.re
@@ -11,75 +11,90 @@ open ViewNode;
 open RenderPass;
 
 class textNode (name: string, text: string) = {
-    as _this;
+  as _this;
+  val mutable text = text;
+  val quad = Assets.quad();
+  val textureShader = Assets.fontShader();
+  inherit (class viewNode)(name) as _super;
+  pub! draw = (pass: renderPass, layer: int, world: Mat4.t) => {
+    /* Draw background first */
+    _super#draw(pass, layer, world);
 
-    val mutable text = text;
-    val quad = Assets.quad();
-    val textureShader = Assets.fontShader();
+    switch (pass) {
+    | SolidPass(m) =>
+      Shaders.CompiledShader.use(textureShader);
 
-    inherit (class viewNode)(name) as _super;
-            
-    pub! draw = (pass: renderPass, layer: int, world: Mat4.t) => {
-        /* Draw background first */
-        _super#draw(pass, layer, world);
+      Shaders.CompiledShader.setUniformMatrix4fv(
+        textureShader,
+        "uWorld",
+        world,
+      );
+      Shaders.CompiledShader.setUniformMatrix4fv(
+        textureShader,
+        "uProjection",
+        m,
+      );
 
-        switch (pass) {
-        | SolidPass(m) => {
-            Shaders.CompiledShader.use(textureShader);
-    
-            Shaders.CompiledShader.setUniformMatrix4fv(textureShader, "uWorld", world);
-            Shaders.CompiledShader.setUniformMatrix4fv(textureShader, "uProjection", m);
+      let style = _super#getStyle();
+      let font = FontCache.load(style.fontFamily, style.fontSize);
+      let dimensions = _super#measurements();
+      let color = style.color;
+      Shaders.CompiledShader.setUniform3fv(
+        textureShader,
+        "uColor",
+        Color.toVec3(color),
+      );
 
-            let style = _super#getStyle();
-            let font = FontCache.load(style.fontFamily, style.fontSize);
-            let dimensions = _super#measurements();
-            let color = style.color;
-            Shaders.CompiledShader.setUniform3fv(textureShader, "uColor", Color.toVec3(color));
+      let render = (s: Fontkit.fk_shape, x: float, y: float) => {
+        let glyph = FontRenderer.getGlyph(font, s.codepoint);
 
-            let render = (s: Fontkit.fk_shape, x: float, y: float) => {
-                let glyph = FontRenderer.getGlyph(font, s.codepoint);
+        let {width, height, bearingX, bearingY, advance, _} = glyph;
 
-                let {width, height, bearingX, bearingY, advance, _} = glyph;
+        let _ = FontRenderer.getTexture(font, s.codepoint);
+        /* TODO: Bind texture */
 
-                let _ = FontRenderer.getTexture(font, s.codepoint);
-                /* TODO: Bind texture */
+        Shaders.CompiledShader.setUniform4f(
+          textureShader,
+          "uPosition",
+          x +. float_of_int(bearingX),
+          y +. float_of_int(dimensions.height) -. float_of_int(bearingY),
+          float_of_int(width),
+          float_of_int(height),
+        );
 
-                Shaders.CompiledShader.setUniform4f(textureShader, "uPosition", 
-                    x +. float_of_int(bearingX),
-                    y +. float_of_int(dimensions.height) -. float_of_int(bearingY),
-                    float_of_int(width),
-                    float_of_int(height));
+        Geometry.draw(quad, textureShader);
 
-                Geometry.draw(quad, textureShader);
+        x +. float_of_int(advance) /. 64.0;
+      };
 
-                x +. float_of_int(advance) /. 64.0;
-            };
-
-            let shapedText = Fontkit.fk_shape(font, text);
-            let startX = ref(float_of_int(dimensions.left));
-            Array.iter(s => {
-                let nextPosition = render(s, startX^, float_of_int(dimensions.top));
-                startX := nextPosition;
-            }, shapedText);
-            }
-        };
+      let shapedText = Fontkit.fk_shape(font, text);
+      let startX = ref(float_of_int(dimensions.left));
+      Array.iter(
+        s => {
+          let nextPosition =
+            render(s, startX^, float_of_int(dimensions.top));
+          startX := nextPosition;
+        },
+        shapedText,
+      );
     };
+  };
+  pub setText = t => text = t;
+  pub! getMeasureFunction = () => {
+    let measure =
+        (_mode, _width, _widthMeasureMode, _height, _heightMeasureMode) => {
+      /* TODO: Cache font locally in variable */
+      let style = _super#getStyle();
+      let font = FontCache.load(style.fontFamily, style.fontSize);
 
-    pub setText = (t) => {
-        text = t;
+      let d = FontRenderer.measure(font, text);
+      print_endline("Measured width: " ++ string_of_int(d.width));
+      let ret: Layout.LayoutTypes.dimensions = {
+        LayoutTypes.width: d.width,
+        height: d.height,
+      };
+      ret;
     };
-
-    pub! getMeasureFunction = () => {
-        let measure = (_mode, _width, _widthMeasureMode, _height, _heightMeasureMode) => {
-                /* TODO: Cache font locally in variable */
-                let style = _super#getStyle();
-                let font = FontCache.load(style.fontFamily, style.fontSize);
-
-                let d = FontRenderer.measure(font, text);
-                print_endline ("Measured width: " ++ string_of_int(d.width));
-                let ret: Layout.LayoutTypes.dimensions = { LayoutTypes.width: d.width, height: d.height };
-                ret;
-        };
-        Some(measure);
-    };
+    Some(measure);
+  };
 };

--- a/src/UI/ViewNode.re
+++ b/src/UI/ViewNode.re
@@ -12,9 +12,8 @@ open RenderPass;
 class viewNode (name: string) = {
     as _this;
 
-    val _quad = Geometry.Cube.create();
-    val solidShader = SolidShader.create();
-
+    val _quad = Assets.quad();
+    val solidShader = Assets.solidShader();
 
     inherit (class node(renderPass))(name) as _super;
 

--- a/src/UI/ViewNode.re
+++ b/src/UI/ViewNode.re
@@ -10,39 +10,50 @@ open Node;
 open RenderPass;
 
 class viewNode (name: string) = {
-    as _this;
+  as _this;
+  val _quad = Assets.quad();
+  val solidShader = Assets.solidShader();
+  inherit (class node(renderPass))(name) as _super;
+  pub! draw = (pass: renderPass, layer: int, world: Mat4.t) => {
+    switch (pass) {
+    | SolidPass(m) =>
+      Shaders.CompiledShader.use(solidShader);
+      Shaders.CompiledShader.setUniformMatrix4fv(
+        solidShader,
+        "uWorld",
+        world,
+      );
+      Shaders.CompiledShader.setUniformMatrix4fv(
+        solidShader,
+        "uProjection",
+        m,
+      );
 
-    val _quad = Assets.quad();
-    val solidShader = Assets.solidShader();
+      let style = _super#getStyle();
+      let dimensions = _super#measurements();
 
-    inherit (class node(renderPass))(name) as _super;
+      /* print_endline ("** NODE: " ++ name ++ " **"); */
+      /* print_endline ("-left: " ++ string_of_int(dimensions.left)); */
+      /* print_endline ("-top: " ++ string_of_int(dimensions.top)); */
+      /* print_endline ("-width: " ++ string_of_int(dimensions.width)); */
+      /* print_endline ("-height: " ++ string_of_int(dimensions.height)); */
 
-    pub! draw = (pass: renderPass, layer: int, world: Mat4.t) => {
-        switch (pass) {
-        | SolidPass(m) => {
-            Shaders.CompiledShader.use(solidShader);
-            Shaders.CompiledShader.setUniformMatrix4fv(solidShader, "uWorld", world);
-            Shaders.CompiledShader.setUniformMatrix4fv(solidShader, "uProjection", m);
-
-            let style = _super#getStyle();
-            let dimensions = _super#measurements();
-
-            /* print_endline ("** NODE: " ++ name ++ " **"); */
-            /* print_endline ("-left: " ++ string_of_int(dimensions.left)); */
-            /* print_endline ("-top: " ++ string_of_int(dimensions.top)); */
-            /* print_endline ("-width: " ++ string_of_int(dimensions.width)); */
-            /* print_endline ("-height: " ++ string_of_int(dimensions.height)); */
-
-            Shaders.CompiledShader.setUniform3fv(solidShader, "uColor", Color.toVec3(style.backgroundColor));
-            Shaders.CompiledShader.setUniform4f(solidShader, "uPosition", 
-                float_of_int(dimensions.left),
-                float_of_int(dimensions.top),
-                float_of_int(dimensions.width),
-                float_of_int(dimensions.height));
-            Geometry.draw(_quad, solidShader);
-        }
-        };
-
-        _super#draw(pass, layer, world);
+      Shaders.CompiledShader.setUniform3fv(
+        solidShader,
+        "uColor",
+        Color.toVec3(style.backgroundColor),
+      );
+      Shaders.CompiledShader.setUniform4f(
+        solidShader,
+        "uPosition",
+        float_of_int(dimensions.left),
+        float_of_int(dimensions.top),
+        float_of_int(dimensions.width),
+        float_of_int(dimensions.height),
+      );
+      Geometry.draw(_quad, solidShader);
     };
+
+    _super#draw(pass, layer, world);
+  };
 };


### PR DESCRIPTION
This fixes several low-hanging performance issues:
- We were rendering cubes (!!) instead of quads for all the geometry
- We were recompiling shaders used in the UI every frame
- We would resize the window while in the middle of rendering - this was problematic for both performance causing stretching artifacts.

I was also experimenting with the impact of vsync on performance, so there is now an option on the window to enable / disable vsync (this can be overridden by driver settings though).

TODO:
- [x] Make performance logging optional and off by default