### PR TITLE
Refactoring: Use local transforms

### DIFF
--- a/examples/Bin.re
+++ b/examples/Bin.re
@@ -10,7 +10,7 @@ let init = app => {
 
   let textHeaderStyle = Style.make(~backgroundColor=Colors.red, ~color=Colors.white, ~fontFamily="Roboto-Regular.ttf", ~fontSize=24, ());
 
-  let smallerTextStyle = Style.make(~backgroundColor=Colors.red, ~color=Colors.white, ~fontFamily="Roboto-Regular.ttf", ~fontSize=12, ());
+  let smallerTextStyle = Style.make(~backgroundColor=Colors.red, ~color=Colors.white, ~fontFamily="Roboto-Regular.ttf", ~fontSize=36, ());
 
   Window.setRenderCallback(w, () => {
     UI.render(ui,

--- a/src/Geometry/Quad.re
+++ b/src/Geometry/Quad.re
@@ -3,7 +3,7 @@ open Revery_Shaders.Shader;
 let create = () => {
   let positions = [|(-0.5), 0.5, 0.5, 0.5, 0.5, (-0.5), (-0.5), (-0.5)|];
 
-  let textureCoordinates = [|0.0, 0.0, 1.0, 0.0, 1.0, 1.0, 0.0, 1.0|];
+  let textureCoordinates = [|0.0, 1.0, 1.0, 1.0, 1.0, 0.0, 0.0, 0.0|];
 
   let indices = [|0, 1, 2, 0, 2, 3|];
 

--- a/src/UI/FontRenderer.re
+++ b/src/UI/FontRenderer.re
@@ -41,7 +41,7 @@ let measure = (font: Fontkit.fk_face, text: string) => {
 
     Array.iter(shape => {
         let {height, bearingY, advance, _} = getGlyph(font, shape.codepoint);
-        let top = height + bearingY;
+        let top = -bearingY;
         let bottom = top + height;
 
         if (height > 0) {

--- a/src/UI/FontShader.re
+++ b/src/UI/FontShader.re
@@ -7,7 +7,11 @@
 open Revery_Shaders;
 open Revery_Shaders.Shader;
 
-let attribute: list(ShaderAttribute.t) = SolidShader.attribute;
+let attribute: list(ShaderAttribute.t) = SolidShader.attribute@[{
+    dataType: ShaderDataType.Vector2,
+    name: "aTexCoord",
+    channel: TextureCoordinate,
+}];
 
 let uniform: list(ShaderUniform.t) = SolidShader.uniform @ [{
     dataType: ShaderDataType.Sampler2D,

--- a/src/UI/Node.re
+++ b/src/UI/Node.re
@@ -30,6 +30,24 @@ class node ('a) (_name: string) = {
 
     pub getStyle = () => _style^;
 
+    pub getLocalTransform = () => {
+      let dimensions = _this#measurements();
+      let left = float_of_int(dimensions.left);
+      let top = float_of_int(dimensions.top);
+      let width = float_of_int(dimensions.width);
+      let height = float_of_int(dimensions.height);
+
+      let scaleTransform = Mat4.create();
+      Mat4.fromScaling(scaleTransform, Vec3.create(width, height, 1.0));
+
+      let translateTransform = Mat4.create();
+      Mat4.fromTranslation(translateTransform, Vec3.create(left +. width /. 2., top +. height /. 2., 1.0));
+
+      let world = Mat4.create();
+      Mat4.multiply(world, translateTransform, scaleTransform);
+      world;
+    };
+
     pub addChild = (n: node('a)) => {
         _children := List.append(_children^, [n]);
     };

--- a/src/UI/SolidShader.re
+++ b/src/UI/SolidShader.re
@@ -10,17 +10,13 @@ open Revery_Shaders.Shader;
 let attribute: list(ShaderAttribute.t) = [
 {
   dataType: ShaderDataType.Vector2,
-  name: "aTexCoord",
-  channel: TextureCoordinate,
+  name: "aPosition",
+  channel: Position,
 }];
 
 let uniform: list(ShaderUniform.t) = [{
     dataType: ShaderDataType.Vector3,
     name: "uColor",
-    usage: VertexShader,
-}, {
-    dataType: ShaderDataType.Vector4,
-    name: "uPosition",
     usage: VertexShader,
 }, {
     dataType: ShaderDataType.Mat4,
@@ -40,7 +36,7 @@ let varying: list(ShaderVarying.t) = [{
 
 
 let vsShader = {|
-   vec4 pos = vec4(uPosition.x + (aTexCoord.x * uPosition.z), uPosition.y + (aTexCoord.y * uPosition.w), 1, 1.0);
+   vec4 pos = vec4(aPosition.x, aPosition.y, 1.0, 1.0);
    gl_Position = uProjection * uWorld * pos;
    vColor = uColor;
 |};

--- a/src/UI/TextNode.re
+++ b/src/UI/TextNode.re
@@ -45,7 +45,7 @@ class textNode (name: string, text: string) = {
         Color.toVec3(color),
       );
 
-      let render = (s: Fontkit.fk_shape, x: float, y: float) => {
+      let render = (s: Fontkit.fk_shape, x: float, _y: float) => {
         let glyph = FontRenderer.getGlyph(font, s.codepoint);
 
         let {width, height, bearingX, bearingY, advance, _} = glyph;
@@ -53,14 +53,19 @@ class textNode (name: string, text: string) = {
         let _ = FontRenderer.getTexture(font, s.codepoint);
         /* TODO: Bind texture */
 
-        Shaders.CompiledShader.setUniform4f(
-          textureShader,
-          "uPosition",
-          x +. float_of_int(bearingX),
-          y +. float_of_int(dimensions.height) -. float_of_int(bearingY),
-          float_of_int(width),
-          float_of_int(height),
-        );
+        let _derp = width;
+        let _derp2 = height;
+        let _derp3 = bearingX;
+        let _derp4 = bearingY;
+
+        /* Shaders.CompiledShader.setUniform4f( */
+        /*   textureShader, */
+        /*   "uPosition", */
+        /*   x +. float_of_int(bearingX), */
+        /*   y +. float_of_int(dimensions.height) -. float_of_int(bearingY), */
+        /*   float_of_int(width), */
+        /*   float_of_int(height), */
+        /* ); */
 
         Geometry.draw(quad, textureShader);
 

--- a/src/UI/TextNode.re
+++ b/src/UI/TextNode.re
@@ -26,11 +26,6 @@ class textNode (name: string, text: string) = {
 
       Shaders.CompiledShader.setUniformMatrix4fv(
         textureShader,
-        "uWorld",
-        world,
-      );
-      Shaders.CompiledShader.setUniformMatrix4fv(
-        textureShader,
         "uProjection",
         m,
       );
@@ -45,7 +40,10 @@ class textNode (name: string, text: string) = {
         Color.toVec3(color),
       );
 
-      let render = (s: Fontkit.fk_shape, x: float, _y: float) => {
+      let outerTransform = Mat4.create();
+      Mat4.fromTranslation(outerTransform, Vec3.create(float_of_int(dimensions.left), float_of_int(dimensions.top) +. float_of_int(dimensions.height), 0.0));
+
+      let render = (s: Fontkit.fk_shape, x: float) => {
         let glyph = FontRenderer.getGlyph(font, s.codepoint);
 
         let {width, height, bearingX, bearingY, advance, _} = glyph;
@@ -53,19 +51,24 @@ class textNode (name: string, text: string) = {
         let _ = FontRenderer.getTexture(font, s.codepoint);
         /* TODO: Bind texture */
 
-        let _derp = width;
-        let _derp2 = height;
-        let _derp3 = bearingX;
-        let _derp4 = bearingY;
+        let  glyphTransform = Mat4.create();
+        Mat4.fromTranslation(glyphTransform, Vec3.create(x +. float_of_int(bearingX) +. (float_of_int(width) /. 2.), (float_of_int(height) *. 0.5) -. float_of_int(bearingY), 0.0));
 
-        /* Shaders.CompiledShader.setUniform4f( */
-        /*   textureShader, */
-        /*   "uPosition", */
-        /*   x +. float_of_int(bearingX), */
-        /*   y +. float_of_int(dimensions.height) -. float_of_int(bearingY), */
-        /*   float_of_int(width), */
-        /*   float_of_int(height), */
-        /* ); */
+        let scaleTransform = Mat4.create();
+        Mat4.fromScaling(scaleTransform, Vec3.create(float_of_int(width), float_of_int(height), 1.0));
+
+        let local = Mat4.create();
+        Mat4.multiply(local, glyphTransform, scaleTransform);
+
+        let xform = Mat4.create();
+        Mat4.multiply(xform, outerTransform, local);
+        Mat4.multiply(xform, world, xform)
+
+          Shaders.CompiledShader.setUniformMatrix4fv(
+            textureShader,
+            "uWorld",
+            xform,
+          );
 
         Geometry.draw(quad, textureShader);
 
@@ -73,11 +76,11 @@ class textNode (name: string, text: string) = {
       };
 
       let shapedText = Fontkit.fk_shape(font, text);
-      let startX = ref(float_of_int(dimensions.left));
+      let startX = ref(0.);
       Array.iter(
         s => {
           let nextPosition =
-            render(s, startX^, float_of_int(dimensions.top));
+            render(s, startX^);
           startX := nextPosition;
         },
         shapedText,

--- a/src/UI/TextureShader.re
+++ b/src/UI/TextureShader.re
@@ -7,7 +7,11 @@
 open Revery_Shaders;
 open Revery_Shaders.Shader;
 
-let attribute: list(ShaderAttribute.t) = SolidShader.attribute;
+let attribute: list(ShaderAttribute.t) = SolidShader.attribute@[{
+    dataType: ShaderDataType.Vector2,
+    name: "aTexCoord",
+    channel: TextureCoordinate,
+}];
 
 let uniform: list(ShaderUniform.t) = SolidShader.uniform @ [{
     dataType: ShaderDataType.Sampler2D,

--- a/src/UI/ViewNode.re
+++ b/src/UI/ViewNode.re
@@ -14,15 +14,10 @@ class viewNode (name: string) = {
   val _quad = Assets.quad();
   val solidShader = Assets.solidShader();
   inherit (class node(renderPass))(name) as _super;
-  pub! draw = (pass: renderPass, layer: int, world: Mat4.t) => {
+  pub! draw = (pass: renderPass, layer: int, w: Mat4.t) => {
     switch (pass) {
     | SolidPass(m) =>
       Shaders.CompiledShader.use(solidShader);
-      Shaders.CompiledShader.setUniformMatrix4fv(
-        solidShader,
-        "uWorld",
-        world,
-      );
       Shaders.CompiledShader.setUniformMatrix4fv(
         solidShader,
         "uProjection",
@@ -30,31 +25,27 @@ class viewNode (name: string) = {
       );
 
       let style = _super#getStyle();
-      let dimensions = _super#measurements();
 
-      /* print_endline ("** NODE: " ++ name ++ " **"); */
-      /* print_endline ("-left: " ++ string_of_int(dimensions.left)); */
-      /* print_endline ("-top: " ++ string_of_int(dimensions.top)); */
-      /* print_endline ("-width: " ++ string_of_int(dimensions.width)); */
-      /* print_endline ("-height: " ++ string_of_int(dimensions.height)); */
+      let world = Mat4.create();
+      let localTransform = _super#getLocalTransform();
+      Mat4.multiply(world, w, localTransform);
+
+      Shaders.CompiledShader.setUniformMatrix4fv(
+        solidShader,
+        "uWorld",
+        world,
+      );
 
       Shaders.CompiledShader.setUniform3fv(
         solidShader,
         "uColor",
         Color.toVec3(style.backgroundColor),
       );
-      Shaders.CompiledShader.setUniform4f(
-        solidShader,
-        "uPosition",
-        float_of_int(dimensions.left),
-        float_of_int(dimensions.top),
-        float_of_int(dimensions.width),
-        float_of_int(dimensions.height),
-      );
+
       Geometry.draw(_quad, solidShader);
     | _ => ()
     };
 
-    _super#draw(pass, layer, world);
+    _super#draw(pass, layer, w);
   };
 };


### PR DESCRIPTION
__Issue:__ We were using some kind of hacky logic to derive vertex positions from texture coordinates for positioning items. This worked, but isn't extensible for a transform pipeline (for example, implementing animations). 

The problem with integrating animations or other functionality is that, sometimes, we want to apply a transform prior to applying the translation into UI / window space - but we don't have that option here, because that implict transformation that happens is always the first thing applied.

__Fix:__ Refactor to use the actual quad positions, which are centered on the origin - meaning we can apply animations that prior to applying transforms into UI/window space.