### PR TITLE
Add Revery_Math to install step

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
         "esy-installer Revery.install",
         "esy-installer Revery_Core.install",
         "esy-installer Revery_Geometry.install",
+        "esy-installer Revery_Math.install",
         "esy-installer Revery_Shaders.install",
         "esy-installer Revery_UI.install"
     ]


### PR DESCRIPTION
Fixes error when bringing `revery` in as a dependency: 
```
# Error: Library "Revery_Math" not found.


 ERROR  C:/Users/bryph/.esy/3_/i/revery-eef9eaab/lib\Revery\META:1 0-0

 1 ┆ version = "dev"
 2 ┆ description = ""
 3 ┆ requires = "Revery_Core
 4 ┆             Revery_Geometry
```