### PR TITLE
Hit Testing - Refactoring: Make world transform available outside of draw

### DIFF
--- a/src/UI/ImageNode.re
+++ b/src/UI/ImageNode.re
@@ -27,7 +27,7 @@ class imageNode (imagePath: string) = {
       let opacity = _super#getStyle().opacity *. parentContext.opacity;
       let localTransform = _super#getLocalTransform();
       let world = Mat4.create();
-      Mat4.multiply(world, parentContext.transform, localTransform);
+      Mat4.multiply(world, _this#getWorldTransform(), localTransform);
 
       Shaders.CompiledShader.setUniformMatrix4fv(
         textureShader,

--- a/src/UI/Node.re
+++ b/src/UI/Node.re
@@ -12,6 +12,15 @@ class node ('a) (()) = {
   val _layoutNode = ref(Layout.createNode([||], Layout.defaultStyle));
   val _parent: ref(option(node('a))) = ref(None);
   pub draw = (pass: 'a, parentContext: NodeDrawContext.t) => {
+    let style: Style.t = _this#getStyle();
+    let matrix = _this#getTransform();
+    let localContext = NodeDrawContext.createFromParent(parentContext, matrix, style.opacity);
+    List.iter(c => c#draw(pass, localContext), _children^);
+  };
+  pub measurements = () => _layoutNode^.layout;
+  pub setStyle = style => _style := style;
+  pub getStyle = () => _style^;
+  pub getTransform = () => {
     let dimensions = _layoutNode^.layout;
     let matrix = Mat4.create();
     Mat4.fromTranslation(
@@ -22,14 +31,15 @@ class node ('a) (()) = {
         0.,
       ),
     );
-    let style: Style.t = _this#getStyle();
-    let localContext =
-      NodeDrawContext.createFromParent(parentContext, matrix, style.opacity);
-    List.iter(c => c#draw(pass, localContext), _children^);
+    matrix;
   };
-  pub measurements = () => _layoutNode^.layout;
-  pub setStyle = style => _style := style;
-  pub getStyle = () => _style^;
+  pub getWorldTransform = () => {
+      let local = _this#getTransform();
+      let world = _parent#getWorldTransform();
+      let matrix = Mat4.create();
+      Mat4.multiply(matrix, world, local);
+      matrix;
+  };
   pub getLocalTransform = () => {
     let dimensions = _this#measurements();
     let left = float_of_int(dimensions.left);

--- a/src/UI/Node.re
+++ b/src/UI/Node.re
@@ -13,8 +13,7 @@ class node ('a) (()) = {
   val _parent: ref(option(node('a))) = ref(None);
   pub draw = (pass: 'a, parentContext: NodeDrawContext.t) => {
     let style: Style.t = _this#getStyle();
-    let matrix = _this#getTransform();
-    let localContext = NodeDrawContext.createFromParent(parentContext, matrix, style.opacity);
+    let localContext = NodeDrawContext.createFromParent(parentContext, style.opacity);
     List.iter(c => c#draw(pass, localContext), _children^);
   };
   pub measurements = () => _layoutNode^.layout;

--- a/src/UI/Node.re
+++ b/src/UI/Node.re
@@ -35,7 +35,10 @@ class node ('a) (()) = {
   };
   pub getWorldTransform = () => {
       let local = _this#getTransform();
-      let world = _parent#getWorldTransform();
+      let world = switch (_parent^) {
+      | None => Mat4.create() 
+      | Some(p) => p#getWorldTransform();
+      };
       let matrix = Mat4.create();
       Mat4.multiply(matrix, world, local);
       matrix;

--- a/src/UI/NodeDrawContext.re
+++ b/src/UI/NodeDrawContext.re
@@ -3,8 +3,6 @@
  *
  * This is context that is passed from parent -> child nodes when redrawing the scene
  */
-open Reglm;
-
 type t = {
     zIndex: int,
     opacity: float

--- a/src/UI/NodeDrawContext.re
+++ b/src/UI/NodeDrawContext.re
@@ -6,29 +6,23 @@
 open Reglm;
 
 type t = {
-    transform: Mat4.t,
     zIndex: int,
     opacity: float
 };
 
-let create = (transform: Mat4.t, zIndex: int, opacity: float) => {
+let create = (zIndex: int, opacity: float) => {
     let ret: t = {
-        transform,
         zIndex,
         opacity
     };
     ret;
 };
 
-let createFromParent = (parentContext: t, localTransform: Mat4.t, localOpacity: float) => {
-    let transform = Mat4.create();
-    Mat4.multiply(transform, parentContext.transform, localTransform);
-
+let createFromParent = (parentContext: t, localOpacity: float) => {
     let zIndex = parentContext.zIndex + 1;
     let opacity = parentContext.opacity *. localOpacity;
 
     let ret: t = {
-        transform,
         zIndex,
         opacity
     };

--- a/src/UI/Revery_UI.re
+++ b/src/UI/Revery_UI.re
@@ -102,13 +102,12 @@ let render = (container: uiContainer, component: UiReact.component) => {
     1000.0,
     -1000.0,
   );
-  let m = Mat4.create();
 
   Performance.bench("draw", () => {
     /* Do a first pass for all 'opaque' geometry */
     /* This helps reduce the overhead for the more expensive alpha pass, next */
 
-    let drawContext = NodeDrawContext.create(m, 0, 1.0);
+    let drawContext = NodeDrawContext.create(0, 1.0);
 
     let solidPass = SolidPass(_projection);
     rootNode#draw(solidPass, drawContext);

--- a/src/UI/TextNode.re
+++ b/src/UI/TextNode.re
@@ -85,7 +85,7 @@ class textNode (text: string) = {
 
         let xform = Mat4.create();
         Mat4.multiply(xform, outerTransform, local);
-        Mat4.multiply(xform, parentContext.transform, xform);
+        Mat4.multiply(xform, _this#getWorldTransform(), xform);
 
         Shaders.CompiledShader.setUniformMatrix4fv(
           textureShader,

--- a/src/UI/ViewNode.re
+++ b/src/UI/ViewNode.re
@@ -28,8 +28,8 @@ class viewNode () = {
       let opacity = style.opacity *. parentContext.opacity;
 
       let world = Mat4.create();
-      let localTransform = _super#getLocalTransform();
-      Mat4.multiply(world, parentContext.transform, localTransform);
+      let localTransform = _this#getLocalTransform();
+      Mat4.multiply(world, _this#getWorldTransform(), localTransform);
 
       Shaders.CompiledShader.setUniformMatrix4fv(
         solidShader,


### PR DESCRIPTION
Currently, we were only using the `worldTransform` (the result of multiplying all parent transforms) in the `draw` method. However, we also need this concept when doing hit testing.

The idea is that we use the `worldTransform` to calculate the axis-aligned bounding box in screen-space (the rectangle encompassing the element), and then check to see if the mouse position is within that AABB. 

This means that we need to decouple it from just rendering and make it available elsewhere.