### PR TITLE
WebGL Compatibility: Remove 'sleep'

### DIFF
--- a/src/Core/App.re
+++ b/src/Core/App.re
@@ -70,7 +70,7 @@ let startWithState: startFunc('s, 'a) =
           appInstance.needsRender = false;
         });
       } else {
-        sleep(Milliseconds(1.));
+        Environment.sleep(Milliseconds(1.));
       };
       false;
     };

--- a/src/Core/App.re
+++ b/src/Core/App.re
@@ -70,7 +70,7 @@ let startWithState: startFunc('s, 'a) =
           appInstance.needsRender = false;
         });
       } else {
-        Unix.sleepf(1. /. 100.);
+        sleep(Milliseconds(1.));
       };
       false;
     };

--- a/src/Core/Color.re
+++ b/src/Core/Color.re
@@ -18,11 +18,8 @@ let rgb = (r: float, g: float, b: float) => {
 };
 
 let multiplyAlpha = (opacity: float, color: t) => {
-    let ret: t = {
-    ...color,
-    a: opacity *. color.a,
-    };
-    ret;
+  let ret: t = {...color, a: opacity *. color.a};
+  ret;
 };
 
 let toVec3 = (color: t) => Vec3.create(color.r, color.g, color.b);

--- a/src/Core/Environment.re
+++ b/src/Core/Environment.re
@@ -6,3 +6,10 @@ let isNative =
   };
 
 let webGL = !isNative;
+
+let sleep = (t: Time.t) => {
+  /* No-op in JS */
+  if (isNative) {
+    Unix.sleepf(Time.to_float_seconds(t)); 
+  }
+}

--- a/src/Core/Environment.re
+++ b/src/Core/Environment.re
@@ -7,9 +7,8 @@ let isNative =
 
 let webGL = !isNative;
 
-let sleep = (t: Time.t) => {
+let sleep = (t: Time.t) =>
   /* No-op in JS */
   if (isNative) {
-    Unix.sleepf(Time.to_float_seconds(t)); 
-  }
-}
+    Unix.sleepf(Time.to_float_seconds(t));
+  };

--- a/src/Core/Revery_Core.re
+++ b/src/Core/Revery_Core.re
@@ -6,6 +6,8 @@ module App = App;
 module Time = Time;
 module Monitor = Monitor;
 
+module Environment = Environment;
+
 module Event = Reactify.Event;
 
 module Performance = Performance;

--- a/src/Core/Time.re
+++ b/src/Core/Time.re
@@ -1,22 +1,17 @@
 open Reglfw.Glfw;
 
-type t = 
-| Seconds(float)
-| Milliseconds(float);
+type t =
+  | Seconds(float)
+  | Milliseconds(float);
 
-let of_float_seconds = (v:float) => {
-    Seconds(v);
-};
+let of_float_seconds = (v: float) => Seconds(v);
 
-let to_float_seconds = (v: t) => {
-    switch (v) {
-    | Seconds(x) => x
-    | Milliseconds(x) => x /. 1000.;
-    }
-}
+let to_float_seconds = (v: t) =>
+  switch (v) {
+  | Seconds(x) => x
+  | Milliseconds(x) => x /. 1000.
+  };
 
-let show = (v: t) => {
-    string_of_float(to_float_seconds(v)) ++ "s";
-};
+let show = (v: t) => string_of_float(to_float_seconds(v)) ++ "s";
 
 let getTime = () => of_float_seconds(glfwGetTime());

--- a/src/Shaders/Shader.re
+++ b/src/Shaders/Shader.re
@@ -5,6 +5,8 @@ open Reglm;
 type vertexShaderSource = string;
 type fragmentShaderSource = string;
 
+module Environment = Revery_Core.Environment;
+
 module VertexChannel = {
   type t =
     | Position

--- a/src/Shaders/Shader.re
+++ b/src/Shaders/Shader.re
@@ -214,7 +214,7 @@ module CompiledShader = {
     _setUniformIfAvailable(s, name, u => glUniform4f(u, x, y, z, w));
 
   let setUniform4fv = (s: t, name: string, v: Vec4.t) =>
-     _setUniformIfAvailable(s, name, u => glUniform4fv(u, v));
+    _setUniformIfAvailable(s, name, u => glUniform4fv(u, v));
 
   let setUniformMatrix4fv = (s: t, name: string, m: Mat4.t) =>
     _setUniformIfAvailable(s, name, u => glUniformMatrix4fv(u, m));

--- a/src/Shaders/dune
+++ b/src/Shaders/dune
@@ -1,4 +1,4 @@
 (library
     (name Revery_Shaders)
     (public_name Revery_Shaders)
-    (libraries lwt lwt.unix reglfw))
+    (libraries lwt lwt.unix reglfw Revery_Core))


### PR DESCRIPTION
__Issue:__ When running in the WebGL strategy, the JS execution fails

__Defect:__ There's no platform stub for the sleep call, and it doesn't make sense in the JS world.

__Fix:__ Create an abstraction for sleep, and only execute Unix.sleep on native / bytecode environments.