### PR TITLE
Refactoring: Clean up geometry / transforms

### DIFF
--- a/examples/Bin.re
+++ b/examples/Bin.re
@@ -63,28 +63,25 @@ module AnimatedText = (
               );
 
             /* TODO: Transforms on text don't work yet */
-            /* let translate: float = */
-            /*   useAnimation( */
-            /*     Animated.floatValue(-100.), */
-            /*     { */
-            /*       toValue: 0., */
-            /*       duration: Seconds(2.), */
-            /*       delay: Seconds(delay), */
-            /*       repeat: false, */
-            /*     }, */
-            /*   ); */
-
-            /* let containerStyle = Style.make(~transform=[TranslateY(translate)], ()); */
+            let translate: float =
+              useAnimation(
+                Animated.floatValue(100.),
+                {
+                  toValue: 0.,
+                  duration: Seconds(2.),
+                  delay: Seconds(delay),
+                  repeat: false,
+                },
+              );
 
             let textHeaderStyle =
               Style.make(
                 ~color=Colors.white,
-                ~backgroundColor=Colors.red,
                 ~fontFamily="Roboto-Regular.ttf",
                 ~fontSize=24,
                 ~marginHorizontal=8,
                 ~opacity,
-                /* ~transform=[TranslateY(translate)], */
+                ~transform=[TranslateY(translate)],
                 (),
               );
 

--- a/examples/Bin.re
+++ b/examples/Bin.re
@@ -109,10 +109,11 @@ let init = app => {
           (),
         )}>
         <Logo />
-        <view style={Style.make(~flexDirection=Row,~alignItems=AlignFlexEnd, ())}>
-        <AnimatedText delay=0.0 textContent="Welcome" />
-        <AnimatedText delay=0.5 textContent="to" />
-        <AnimatedText delay=1. textContent="Revery" />
+        <view
+          style={Style.make(~flexDirection=Row, ~alignItems=AlignFlexEnd, ())}>
+          <AnimatedText delay=0.0 textContent="Welcome" />
+          <AnimatedText delay=0.5 textContent="to" />
+          <AnimatedText delay=1. textContent="Revery" />
         </view>
       </view>,
     )

--- a/examples/Bin.re
+++ b/examples/Bin.re
@@ -62,7 +62,6 @@ module AnimatedText = (
                 },
               );
 
-            /* TODO: Transforms on text don't work yet */
             let translate: float =
               useAnimation(
                 Animated.floatValue(100.),

--- a/examples/Bin.re
+++ b/examples/Bin.re
@@ -79,6 +79,7 @@ module AnimatedText = (
             let textHeaderStyle =
               Style.make(
                 ~color=Colors.white,
+                ~backgroundColor=Colors.red,
                 ~fontFamily="Roboto-Regular.ttf",
                 ~fontSize=24,
                 ~marginHorizontal=8,

--- a/src/Geometry/Quad.re
+++ b/src/Geometry/Quad.re
@@ -1,7 +1,7 @@
 open Revery_Shaders.Shader;
 
-let create = () => {
-  let positions = [|(-0.5), 0.5, 0.5, 0.5, 0.5, (-0.5), (-0.5), (-0.5)|];
+let create = (minX, minY,maxX, maxY) => {
+  let positions = [|minX, maxY, maxX, maxY, maxX, minY, minX, minY|];
 
   let textureCoordinates = [|0.0, 1.0, 1.0, 1.0, 1.0, 0.0, 0.0, 0.0|];
 

--- a/src/UI/Assets.re
+++ b/src/UI/Assets.re
@@ -4,10 +4,14 @@
  * Lazily initialized assets to be re-used across frames
  */
 module Lazy = Revery_Core.Lazy;
+module Memoize = Revery_Core.Memoize;
 module Geometry = Revery_Geometry;
 
 let solidShader = Lazy.make(() => SolidShader.create());
 let fontShader = Lazy.make(() => FontShader.create());
 let textureShader = Lazy.make(() => TextureShader.create());
 
-let quad = Lazy.make(() => Geometry.Quad.create());
+let _createQuad = ((minX, minY, maxX, maxY)) => Geometry.Quad.create(minX, minY, maxX, maxY);
+let _memoizedCreateQuad = Memoize.make(_createQuad);
+
+let quad = (~minX:float=-0.5, ~minY:float=-0.5, ~maxX:float=0.5, ~maxY:float=0.5, ()) => _memoizedCreateQuad((minX, minY, maxX, maxY));

--- a/src/UI/Assets.re
+++ b/src/UI/Assets.re
@@ -11,7 +11,16 @@ let solidShader = Lazy.make(() => SolidShader.create());
 let fontShader = Lazy.make(() => FontShader.create());
 let textureShader = Lazy.make(() => TextureShader.create());
 
-let _createQuad = ((minX, minY, maxX, maxY)) => Geometry.Quad.create(minX, minY, maxX, maxY);
+let _createQuad = ((minX, minY, maxX, maxY)) =>
+  Geometry.Quad.create(minX, minY, maxX, maxY);
 let _memoizedCreateQuad = Memoize.make(_createQuad);
 
-let quad = (~minX:float=-0.5, ~minY:float=-0.5, ~maxX:float=0.5, ~maxY:float=0.5, ()) => _memoizedCreateQuad((minX, minY, maxX, maxY));
+let quad =
+    (
+      ~minX: float=(-0.5),
+      ~minY: float=(-0.5),
+      ~maxX: float=0.5,
+      ~maxY: float=0.5,
+      (),
+    ) =>
+  _memoizedCreateQuad((minX, minY, maxX, maxY));

--- a/src/UI/ImageNode.re
+++ b/src/UI/ImageNode.re
@@ -27,7 +27,8 @@ class imageNode (imagePath: string) = {
       let dimensions = _this#measurements();
       let width = float_of_int(dimensions.width);
       let height = float_of_int(dimensions.height);
-      let quad = Assets.quad(~minX=0., ~minY=0., ~maxX=width, ~maxY=height, ());
+      let quad =
+        Assets.quad(~minX=0., ~minY=0., ~maxX=width, ~maxY=height, ());
 
       let opacity = _super#getStyle().opacity *. parentContext.opacity;
 

--- a/src/UI/ImageNode.re
+++ b/src/UI/ImageNode.re
@@ -12,7 +12,7 @@ open RenderPass;
 
 class imageNode (imagePath: string) = {
   as _this;
-  val _quad = Assets.quad();
+  /* val _quad = Assets.quad(); */
   val textureShader = Assets.textureShader();
   val texture = ImageRenderer.getTexture(imagePath);
   inherit (class node(renderPass))() as _super;
@@ -24,8 +24,14 @@ class imageNode (imagePath: string) = {
     | AlphaPass(m) =>
       Shaders.CompiledShader.use(textureShader);
 
+      let dimensions = _this#measurements();
+      let width = float_of_int(dimensions.width);
+      let height = float_of_int(dimensions.height);
+      let quad = Assets.quad(~minX=0., ~minY=0., ~maxX=width, ~maxY=height, ());
+
       let opacity = _super#getStyle().opacity *. parentContext.opacity;
       let localTransform = _super#getLocalTransform();
+
       let world = Mat4.create();
       Mat4.multiply(world, parentContext.transform, localTransform);
 
@@ -47,7 +53,7 @@ class imageNode (imagePath: string) = {
       );
 
       glBindTexture(GL_TEXTURE_2D, texture);
-      Geometry.draw(_quad, textureShader);
+      Geometry.draw(quad, textureShader);
     | _ => ()
     };
   };

--- a/src/UI/ImageNode.re
+++ b/src/UI/ImageNode.re
@@ -12,7 +12,6 @@ open RenderPass;
 
 class imageNode (imagePath: string) = {
   as _this;
-  /* val _quad = Assets.quad(); */
   val textureShader = Assets.textureShader();
   val texture = ImageRenderer.getTexture(imagePath);
   inherit (class node(renderPass))() as _super;

--- a/src/UI/ImageNode.re
+++ b/src/UI/ImageNode.re
@@ -30,10 +30,8 @@ class imageNode (imagePath: string) = {
       let quad = Assets.quad(~minX=0., ~minY=0., ~maxX=width, ~maxY=height, ());
 
       let opacity = _super#getStyle().opacity *. parentContext.opacity;
-      let localTransform = _super#getLocalTransform();
 
-      let world = Mat4.create();
-      Mat4.multiply(world, _this#getWorldTransform(), localTransform);
+      let world = _this#getWorldTransform();
 
       Shaders.CompiledShader.setUniformMatrix4fv(
         textureShader,

--- a/src/UI/Node.re
+++ b/src/UI/Node.re
@@ -31,7 +31,12 @@ class node ('a) (()) = {
         0.,
       ),
     );
-    let animationTransform = Transform.toMat4(float_of_int(dimensions.width) /. 2., float_of_int(dimensions.height) /. 2., _this#getStyle().transform);
+    let animationTransform =
+      Transform.toMat4(
+        float_of_int(dimensions.width) /. 2.,
+        float_of_int(dimensions.height) /. 2.,
+        _this#getStyle().transform,
+      );
     Mat4.multiply(matrix, matrix, animationTransform);
     matrix;
   };

--- a/src/UI/Node.re
+++ b/src/UI/Node.re
@@ -31,6 +31,8 @@ class node ('a) (()) = {
         0.,
       ),
     );
+    let animationTransform = Transform.toMat4(_this#getStyle().transform);
+    Mat4.multiply(matrix, matrix, animationTransform);
     matrix;
   };
   pub getWorldTransform = () => {
@@ -43,10 +45,6 @@ class node ('a) (()) = {
     let matrix = Mat4.create();
     Mat4.multiply(matrix, world, xform);
     matrix;
-  };
-  pub getLocalTransform = () => {
-    let animationTransform = Transform.toMat4(_this#getStyle().transform);
-    animationTransform;
   };
   pub hitTest = (_p: Vec2.t) =>
     /* TODO: Implement hit test against transforms */

--- a/src/UI/Node.re
+++ b/src/UI/Node.re
@@ -34,23 +34,19 @@ class node ('a) (()) = {
     let dimensions = _this#measurements();
     let left = float_of_int(dimensions.left);
     let top = float_of_int(dimensions.top);
-    let width = float_of_int(dimensions.width);
-    let height = float_of_int(dimensions.height);
-
-    let scaleTransform = Mat4.create();
-    Mat4.fromScaling(scaleTransform, Vec3.create(width, height, 1.0));
+    /* let width = float_of_int(dimensions.width); */
+    /* let height = float_of_int(dimensions.height); */
 
     let animationTransform = Transform.toMat4(_this#getStyle().transform);
 
     let translateTransform = Mat4.create();
     Mat4.fromTranslation(
       translateTransform,
-      Vec3.create(left +. width /. 2., top +. height /. 2., 1.0),
+      Vec3.create(left, top, 1.0),
     );
 
     let world = Mat4.create();
-    Mat4.multiply(world, animationTransform, scaleTransform);
-    Mat4.multiply(world, translateTransform, world);
+    Mat4.multiply(world, translateTransform, animationTransform);
     world;
   };
   pub hitTest = (_p: Vec2.t) =>

--- a/src/UI/Node.re
+++ b/src/UI/Node.re
@@ -31,7 +31,7 @@ class node ('a) (()) = {
         0.,
       ),
     );
-    let animationTransform = Transform.toMat4(_this#getStyle().transform);
+    let animationTransform = Transform.toMat4(float_of_int(dimensions.width) /. 2., float_of_int(dimensions.height) /. 2., _this#getStyle().transform);
     Mat4.multiply(matrix, matrix, animationTransform);
     matrix;
   };

--- a/src/UI/Transform.re
+++ b/src/UI/Transform.re
@@ -17,16 +17,19 @@ let up = Vec3.up();
 let forward = Vec3.forward();
 
 let _rotateWithOrigin = (x: float, y: float, angle, axis, m: Mat4.t) => {
-   let preTranslate = Mat4.create();
-   let postTranslate = Mat4.create();
-   let rotation = Mat4.create();
+  let preTranslate = Mat4.create();
+  let postTranslate = Mat4.create();
+  let rotation = Mat4.create();
 
-   Mat4.fromTranslation(preTranslate, Vec3.create((-1. *. x), (-1. *. y), 0.));
-   Mat4.fromRotation(rotation, angle, axis);
-   Mat4.fromTranslation(postTranslate, Vec3.create(x, y, 0.));
+  Mat4.fromTranslation(
+    preTranslate,
+    Vec3.create((-1.) *. x, (-1.) *. y, 0.),
+  );
+  Mat4.fromRotation(rotation, angle, axis);
+  Mat4.fromTranslation(postTranslate, Vec3.create(x, y, 0.));
 
-   Mat4.multiply(m, rotation, preTranslate);
-   Mat4.multiply(m, postTranslate, m);
+  Mat4.multiply(m, rotation, preTranslate);
+  Mat4.multiply(m, postTranslate, m);
 };
 
 let _toMat4 = (originX: float, originY: float, t) => {

--- a/src/UI/Transform.re
+++ b/src/UI/Transform.re
@@ -16,13 +16,26 @@ let right = Vec3.right();
 let up = Vec3.up();
 let forward = Vec3.forward();
 
-let _toMat4 = t => {
+let _rotateWithOrigin = (x: float, y: float, angle, axis, m: Mat4.t) => {
+   let preTranslate = Mat4.create();
+   let postTranslate = Mat4.create();
+   let rotation = Mat4.create();
+
+   Mat4.fromTranslation(preTranslate, Vec3.create((-1. *. x), (-1. *. y), 0.));
+   Mat4.fromRotation(rotation, angle, axis);
+   Mat4.fromTranslation(postTranslate, Vec3.create(x, y, 0.));
+
+   Mat4.multiply(m, rotation, preTranslate);
+   Mat4.multiply(m, postTranslate, m);
+};
+
+let _toMat4 = (originX: float, originY: float, t) => {
   let m = Mat4.create();
   switch (t) {
-  | RotateX(a) => Mat4.fromRotation(m, a, right)
-  | RotateY(a) => Mat4.fromRotation(m, a, up)
-  | RotateZ(a) => Mat4.fromRotation(m, a, forward)
-  | Rotate(a) => Mat4.fromRotation(m, a, forward)
+  | RotateX(a) => _rotateWithOrigin(originX, originY, a, right, m)
+  | RotateY(a) => _rotateWithOrigin(originX, originY, a, up, m)
+  | RotateZ(a) => _rotateWithOrigin(originX, originY, a, forward, m)
+  | Rotate(a) => _rotateWithOrigin(originX, originY, a, forward, m)
   | Scale(a) => Mat4.fromScaling(m, Vec3.create(a, a, a))
   | ScaleX(a) => Mat4.fromScaling(m, Vec3.create(a, 1., 1.))
   | ScaleY(a) => Mat4.fromScaling(m, Vec3.create(1., a, 1.))
@@ -33,11 +46,11 @@ let _toMat4 = t => {
   m;
 };
 
-let toMat4 = (transforms: list(t)) => {
+let toMat4 = (originX, originY, transforms: list(t)) => {
   let r =
     List.fold_left(
       (prev, transform) => {
-        let xfm = _toMat4(transform);
+        let xfm = _toMat4(originX, originY, transform);
         Mat4.multiply(prev, prev, xfm);
         prev;
       },

--- a/src/UI/Transform.rei
+++ b/src/UI/Transform.rei
@@ -12,4 +12,4 @@ type t =
 | TranslateX(float)
 | TranslateY(float);
 
-let toMat4: list(t) => Mat4.t;
+let toMat4: (float, float, list(t)) => Mat4.t;

--- a/src/UI/ViewNode.re
+++ b/src/UI/ViewNode.re
@@ -5,7 +5,7 @@ module Geometry = Revery_Geometry;
 module Layout = Layout;
 module LayoutTypes = Layout.LayoutTypes;
 
-open Reglm;
+/* open Reglm; */
 open Node;
 open RenderPass;
 
@@ -32,9 +32,7 @@ class viewNode (()) = {
       let style = _super#getStyle();
       let opacity = style.opacity *. parentContext.opacity;
 
-      let world = Mat4.create();
-      let localTransform = _this#getLocalTransform();
-      Mat4.multiply(world, _this#getWorldTransform(), localTransform);
+      let world = _this#getWorldTransform();
 
       Shaders.CompiledShader.setUniformMatrix4fv(
         solidShader,

--- a/src/UI/ViewNode.re
+++ b/src/UI/ViewNode.re
@@ -16,12 +16,12 @@ class viewNode (()) = {
   pub! draw = (pass: renderPass, parentContext: NodeDrawContext.t) => {
     switch (pass) {
     | AlphaPass(m) =>
-
       let dimensions = _this#measurements();
       let width = float_of_int(dimensions.width);
       let height = float_of_int(dimensions.height);
-      let quad = Assets.quad(~minX=0., ~minY=0., ~maxX=width, ~maxY=height, ());
-      
+      let quad =
+        Assets.quad(~minX=0., ~minY=0., ~maxX=width, ~maxY=height, ());
+
       Shaders.CompiledShader.use(solidShader);
       Shaders.CompiledShader.setUniformMatrix4fv(
         solidShader,

--- a/src/UI/ViewNode.re
+++ b/src/UI/ViewNode.re
@@ -11,12 +11,17 @@ open RenderPass;
 
 class viewNode () = {
   as _this;
-  val _quad = Assets.quad();
   val solidShader = Assets.solidShader();
   inherit (class node(renderPass))() as _super;
   pub! draw = (pass: renderPass, parentContext: NodeDrawContext.t) => {
     switch (pass) {
     | AlphaPass(m) =>
+
+      let dimensions = _this#measurements();
+      let width = float_of_int(dimensions.width);
+      let height = float_of_int(dimensions.height);
+      let quad = Assets.quad(~minX=0., ~minY=0., ~maxX=width, ~maxY=height, ());
+      
       Shaders.CompiledShader.use(solidShader);
       Shaders.CompiledShader.setUniformMatrix4fv(
         solidShader,
@@ -45,7 +50,7 @@ class viewNode () = {
         Color.toVec4(c),
       );
 
-      Geometry.draw(_quad, solidShader);
+      Geometry.draw(quad, solidShader);
     | _ => ()
     };
 


### PR DESCRIPTION
This refactoring consolidates the __transform__ concepts. Each Node has a `worldTransform` (which is the combined matrix for getting a quad into screen space - incorporating the full chain of parent transforms), and a local transform `transform` (the left/top offset, and any `Transform`'s applied).

This means that transforms are properly chained (ie, before, they did not impact text elements) - parent transforms get applied to nested transforms.

One thing that was also confusing before is that we always used a Quad with corners at `-0.5, -0.5 -> 0.5, 0.5`. If a UI element was 200x400, we would have to apply both a _translation_ and _scale_ transform. This was extra awkward because we would apply the scale, _animations_, and then translation - hard to reason about how this should be hooked up in the child hierarchy. This made adding things like box-shadows and borders extra-complicated. Now, instead, we just create the Quad at the right local size, and do away with those transforms.

For features like border, we'd just create `Quad` in the right space in the local Node. For example, if we had a `4px` top border on our 200x400 element, we'd create a new Quad with corners at `0, -4 -> 200, 0` for that border.

In addition, the world transform is needed for hit testing - we now can unblock that scenario and actually execute hit testing against nodes now.