### PR TITLE
Fix #94 - Use GL_CLAMP_TO_EDGE for font rendering

### DIFF
--- a/src/UI/FontRenderer.re
+++ b/src/UI/FontRenderer.re
@@ -22,8 +22,8 @@ let _getTexture = ((font: Fontkit.fk_face, codepoint: int)) => {
 
   let texture = glCreateTexture();
   glBindTexture(GL_TEXTURE_2D, texture);
-  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_REPEAT);
-  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_REPEAT);
+  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
   glTexImage2D(GL_TEXTURE_2D, image);


### PR DESCRIPTION
Font rendering looks much better with proper texture wrap settings:

![image](https://user-images.githubusercontent.com/13532591/49607371-9c4d2e00-f94a-11e8-85c5-a905246c8a94.png)

vs

![image](https://user-images.githubusercontent.com/13532591/49607378-a0794b80-f94a-11e8-99d3-2d8825a7ac85.png)

