### PR TITLE
Input - Mouse: Initial hitTest implementation

### DIFF
--- a/src/UI/Layout.re
+++ b/src/UI/Layout.re
@@ -29,8 +29,11 @@ let createNodeWithMeasure = (children, style, measure) =>
     ~andMeasure=measure,
     rootContext,
   );
-let layoutNode = node =>
-  Layout.layoutNode(node, Encoding.cssUndefined, Encoding.cssUndefined, Ltr);
+
+let layout = (node, pixelRatio) => {
+  let layoutNode = node#toLayoutNode(pixelRatio);
+  Layout.layoutNode(layoutNode, Encoding.cssUndefined, Encoding.cssUndefined, Ltr);
+};
 let printCssNode = root =>
   LayoutPrint.printCssNode((
     root,

--- a/src/UI/Layout.re
+++ b/src/UI/Layout.re
@@ -29,7 +29,6 @@ let createNodeWithMeasure = (children, style, measure) =>
     ~andMeasure=measure,
     rootContext,
   );
-
 let layout = (node, pixelRatio) => {
   let layoutNode = node#toLayoutNode(pixelRatio);
   Layout.layoutNode(layoutNode, Encoding.cssUndefined, Encoding.cssUndefined, Ltr);

--- a/src/UI/Layout.re
+++ b/src/UI/Layout.re
@@ -31,7 +31,12 @@ let createNodeWithMeasure = (children, style, measure) =>
   );
 let layout = (node, pixelRatio) => {
   let layoutNode = node#toLayoutNode(pixelRatio);
-  Layout.layoutNode(layoutNode, Encoding.cssUndefined, Encoding.cssUndefined, Ltr);
+  Layout.layoutNode(
+    layoutNode,
+    Encoding.cssUndefined,
+    Encoding.cssUndefined,
+    Ltr,
+  );
 };
 let printCssNode = root =>
   LayoutPrint.printCssNode((

--- a/src/UI/Node.re
+++ b/src/UI/Node.re
@@ -54,7 +54,11 @@ class node ('a) (()) = {
   pub hitTest = (p: Vec2.t) => {
     let dimensions = _layoutNode^.layout;
     let min = Vec2.create(0., 0.);
-    let max = Vec2.create(float_of_int(dimensions.width), float_of_int(dimensions.height));
+    let max =
+      Vec2.create(
+        float_of_int(dimensions.width),
+        float_of_int(dimensions.height),
+      );
     let b = BoundingBox2d.create(min, max);
     let bbox = BoundingBox2d.transform(b, _this#getWorldTransform());
 

--- a/src/UI/Node.re
+++ b/src/UI/Node.re
@@ -3,7 +3,7 @@ module Geometry = Revery_Geometry;
 module Layout = Layout;
 module LayoutTypes = Layout.LayoutTypes;
 
-open Reglm;
+open Revery_Math;
 
 class node ('a) (()) = {
   as _this;
@@ -51,9 +51,15 @@ class node ('a) (()) = {
     Mat4.multiply(matrix, world, xform);
     matrix;
   };
-  pub hitTest = (_p: Vec2.t) =>
-    /* TODO: Implement hit test against transforms */
-    false;
+  pub hitTest = (p: Vec2.t) => {
+    let dimensions = _layoutNode^.layout;
+    let min = Vec2.create(0., 0.);
+    let max = Vec2.create(float_of_int(dimensions.width), float_of_int(dimensions.height));
+    let b = BoundingBox2d.create(min, max);
+    let bbox = BoundingBox2d.transform(b, _this#getWorldTransform());
+
+    BoundingBox2d.isPointInside(bbox, p);
+  };
   pub addChild = (n: node('a)) => {
     _children := List.append(_children^, [n]);
     n#_setParent(Some((_this :> node('a))));

--- a/src/UI/Revery_UI.re
+++ b/src/UI/Revery_UI.re
@@ -61,11 +61,6 @@ let create = (~createOptions=defaultUiContainerOptions, window: Window.t) => {
   ret;
 };
 
-let layout = (node, pixelRatio) => {
-  let rootLayoutNode = node#toLayoutNode(pixelRatio);
-  Layout.layoutNode(rootLayoutNode);
-};
-
 let _projection = Mat4.create();
 
 let render = (container: uiContainer, component: UiReact.component) => {
@@ -90,10 +85,10 @@ let render = (container: uiContainer, component: UiReact.component) => {
         (),
       ),
     );
-    layout(rootNode, pixelRatio);
+    Layout.layout(rootNode, pixelRatio);
   | true =>
     rootNode#setStyle(Style.make());
-    layout(rootNode, pixelRatio);
+    Layout.layout(rootNode, pixelRatio);
     let measurements = rootNode#measurements();
     let size: Window.windowSize = {
       width: measurements.width,

--- a/test/UI/NodeTests.re
+++ b/test/UI/NodeTests.re
@@ -4,69 +4,70 @@ open Revery_Math;
 open Revery_UI;
 
 test("NodeTests", () => {
+  test("no children initially", () => {
+    let node = (new node)();
 
-    test("no children initially", () => {
-        let node = new node();
+    expect(List.length(node#getChildren())).toBe(0);
+  });
 
-        expect(List.length(node#getChildren())).toBe(0);
+  test("add / remove child", () => {
+    let parentNode = (new node)();
+    let childNode = (new node)();
+
+    expect(childNode#getParent()).toBe(None);
+
+    parentNode#addChild(childNode);
+
+    expect(List.length(parentNode#getChildren())).toBe(1);
+    expect(childNode#getParent()).toBe(Some(parentNode));
+
+    parentNode#removeChild(childNode);
+
+    expect(List.length(parentNode#getChildren())).toBe(0);
+    expect(childNode#getParent()).toBe(None);
+  });
+
+  test("hitTest", () => {
+    test("simple hitTest returns true case", () => {
+      let node = (new node)();
+      node#setStyle(Style.make(~width=400, ~height=500, ()));
+
+      Layout.layout(node, 1);
+
+      expect(node#hitTest(Vec2.create(200., 250.))).toBe(true);
     });
 
-    test("add / remove child", () => {
-        let parentNode = new node();
-        let childNode = new node();
+    test("simple hitTest returns false case", () => {
+      let node = (new node)();
+      node#setStyle(Style.make(~width=400, ~height=500, ()));
 
-        expect(childNode#getParent()).toBe(None);
+      Layout.layout(node, 1);
 
-        parentNode#addChild(childNode);
-
-        expect(List.length(parentNode#getChildren())).toBe(1);
-        expect(childNode#getParent()).toBe(Some(parentNode));
-
-        parentNode#removeChild(childNode);
-
-        expect(List.length(parentNode#getChildren())).toBe(0);
-        expect(childNode#getParent()).toBe(None);
+      expect(node#hitTest(Vec2.create(401., 250.))).toBe(false);
     });
 
-    test("hitTest", () => {
-        test("simple hitTest returns true case", () => {
-            let node = new node();
-            node#setStyle(Style.make(~width=400, ~height=500, ()));
+    test("left / top are taken into account", () => {
+      let node = (new node)();
+      node#setStyle(Style.make(~top=5, ~left=5, ~height=2, ~width=2, ()));
 
-            Layout.layout(node, 1);
-
-            expect(node#hitTest(Vec2.create(200., 250.))).toBe(true);
-        });
-
-        test("simple hitTest returns false case", () => {
-            let node = new node();
-            node#setStyle(Style.make(~width=400, ~height=500, ()));
-
-            Layout.layout(node, 1);
-
-            expect(node#hitTest(Vec2.create(401., 250.))).toBe(false);
-        });
-
-        test("left / top are taken into account", () => {
-          let node = new node();  
-          node#setStyle(Style.make(~top=5, ~left=5, ~height=2, ~width=2, ()));
-
-          Layout.layout(node, 1);
-          expect(node#hitTest(Vec2.create(1., 1.))).toBe(false);
-          expect(node#hitTest(Vec2.create(6., 6.))).toBe(true);
-        });
-
-        test("parent transforms are taken into account", () => {
-          let parentNode = new node();  
-          parentNode#setStyle(Style.make(~top=50, ~left=50, ~height=100, ~width=100, ()));
-
-          let childNode = new node();
-          childNode#setStyle(Style.make(~width=25, ~height=25, ()));
-          parentNode#addChild(childNode);
-
-          Layout.layout(parentNode, 1);
-          expect(childNode#hitTest(Vec2.create(0., 0.))).toBe(false);
-          expect(childNode#hitTest(Vec2.create(60., 60.))).toBe(true);
-        });
+      Layout.layout(node, 1);
+      expect(node#hitTest(Vec2.create(1., 1.))).toBe(false);
+      expect(node#hitTest(Vec2.create(6., 6.))).toBe(true);
     });
+
+    test("parent transforms are taken into account", () => {
+      let parentNode = (new node)();
+      parentNode#setStyle(
+        Style.make(~top=50, ~left=50, ~height=100, ~width=100, ()),
+      );
+
+      let childNode = (new node)();
+      childNode#setStyle(Style.make(~width=25, ~height=25, ()));
+      parentNode#addChild(childNode);
+
+      Layout.layout(parentNode, 1);
+      expect(childNode#hitTest(Vec2.create(0., 0.))).toBe(false);
+      expect(childNode#hitTest(Vec2.create(60., 60.))).toBe(true);
+    });
+  });
 });

--- a/test/UI/NodeTests.re
+++ b/test/UI/NodeTests.re
@@ -1,5 +1,6 @@
 open Rejest;
 
+open Revery_Math;
 open Revery_UI;
 
 test("NodeTests", () => {
@@ -25,5 +26,47 @@ test("NodeTests", () => {
 
         expect(List.length(parentNode#getChildren())).toBe(0);
         expect(childNode#getParent()).toBe(None);
+    });
+
+    test("hitTest", () => {
+        test("simple hitTest returns true case", () => {
+            let node = new node();
+            node#setStyle(Style.make(~width=400, ~height=500, ()));
+
+            Layout.layout(node, 1);
+
+            expect(node#hitTest(Vec2.create(200., 250.))).toBe(true);
+        });
+
+        test("simple hitTest returns false case", () => {
+            let node = new node();
+            node#setStyle(Style.make(~width=400, ~height=500, ()));
+
+            Layout.layout(node, 1);
+
+            expect(node#hitTest(Vec2.create(401., 250.))).toBe(false);
+        });
+
+        test("left / top are taken into account", () => {
+          let node = new node();  
+          node#setStyle(Style.make(~top=5, ~left=5, ~height=2, ~width=2, ()));
+
+          Layout.layout(node, 1);
+          expect(node#hitTest(Vec2.create(1., 1.))).toBe(false);
+          expect(node#hitTest(Vec2.create(6., 6.))).toBe(true);
+        });
+
+        test("parent transforms are taken into account", () => {
+          let parentNode = new node();  
+          parentNode#setStyle(Style.make(~top=50, ~left=50, ~height=100, ~width=100, ()));
+
+          let childNode = new node();
+          childNode#setStyle(Style.make(~width=25, ~height=25, ()));
+          parentNode#addChild(childNode);
+
+          Layout.layout(parentNode, 1);
+          expect(childNode#hitTest(Vec2.create(0., 0.))).toBe(false);
+          expect(childNode#hitTest(Vec2.create(60., 60.))).toBe(true);
+        });
     });
 });

--- a/test/UI/Tests.re
+++ b/test/UI/Tests.re
@@ -3,9 +3,9 @@ open Rejest;
 open Revery_UI;
 
 test("UI: Placeholder test", () => {
-    expect(2).toBe(2);
+  expect(2).toBe(2);
 
-    let node = new node();
+  let node = (new node)();
 
-    expect(List.length(node#getChildren())).toBe(0);
+  expect(List.length(node#getChildren())).toBe(0);
 });

--- a/test/UI/dune
+++ b/test/UI/dune
@@ -2,4 +2,4 @@
     (name Revery_UI_Test)
     (library_flags (-linkall))
     (modules (:standard))
-    (libraries Revery_UI rejest))
+    (libraries Revery_UI Revery_Math rejest))


### PR DESCRIPTION
This implements a `hitTest` function on `node` which returns `true` if a point is within a node's bounding box, taking into account upstream parent transforms.

This is an important  pre-requisite for mouse input - since we need to know which node(s) the cursor is over so that we can properly dispatch events to the UI.