### PR TITLE
API: Simplify UI creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,26 +79,23 @@ open Revery.UI;
 let init = app => {
 
   /* Create a window! */
-  let w = App.createWindow(app, "test");
-
-  /* Create a UI 'container' */
-  let ui = UI.create(w);
+  let win = App.createWindow(app, "test");
 
   /* Set up some styles */
   let textHeaderStyle = Style.make(~backgroundColor=Colors.black, ~color=Colors.white, ~fontFamily="Roboto-Regular.ttf", ~fontSize=24, ());
 
-  /* Set up our render function */
-  Window.setRenderCallback(w, () => {
+  /* Set up render function */
+  let render = () => {
+      <view style=(Style.make(~position=LayoutTypes.Absolute, ~bottom=10, ~top=10, ~left=10, ~right=10, ~backgroundColor=Colors.blue, ()))>
+          <view style=(Style.make(~position=LayoutTypes.Absolute, ~bottom=0, ~width=10, ~height=10, ~backgroundColor=Colors.red, ())) />
+          <image src="logo.png" style=(Style.make(~width=128, ~height=64, ())) />
+          <text style=(textHeaderStyle)>"Hello World!"</text>
+          <view style=(Style.make(~width=25, ~height=25, ~backgroundColor=Colors.green, ())) />
+      </view>
+   };
 
-    /* This is where we render the UI - if you've used React or ReasonReact, it should look familiar */
-    UI.render(ui,
-        <view style=(Style.make(~position=LayoutTypes.Absolute, ~bottom=10, ~top=10, ~left=10, ~right=10, ~backgroundColor=Colors.blue, ()))>
-            <view style=(Style.make(~position=LayoutTypes.Absolute, ~bottom=0, ~width=10, ~height=10, ~backgroundColor=Colors.red, ())) />
-            <image src="logo.png" style=(Style.make(~width=128, ~height=64, ())) />
-            <text style=(textHeaderStyle)>"Hello World!"</text>
-            <view style=(Style.make(~width=25, ~height=25, ~backgroundColor=Colors.green, ())) />
-        </view>);
-  });
+  /* Start the UI */
+  UI.start(win, render);
 };
 
 /* Let's get this party started! */

--- a/examples/Autocomplete.re
+++ b/examples/Autocomplete.re
@@ -131,35 +131,36 @@ let init = app => {
 
   /* Listen to key down events, and coerce them into actions, too */
   let _ =
-    Event.subscribe(w.onKeyDown, keyEvent =>
+    Event.subscribe(w.onKeyDown, keyEvent
       /* TODO: Can we implement this API w/o GLFW leaking through? */
-      if (keyEvent.key == Glfw.Key.GLFW_KEY_BACKSPACE) {
-        App.dispatch(app, Backspace);
-      } else if (keyEvent.key == Glfw.Key.GLFW_KEY_H && keyEvent.ctrlKey) {
-        App.dispatch(app, Backspace);
-      } else if (keyEvent.key == Glfw.Key.GLFW_KEY_ESCAPE) {
-        App.quit(0);
-      } else if (keyEvent.key == Glfw.Key.GLFW_KEY_W && keyEvent.ctrlKey) {
-        App.dispatch(app, ClearWord);
-      }
-    );
+      =>
+        if (keyEvent.key == Glfw.Key.GLFW_KEY_BACKSPACE) {
+          App.dispatch(app, Backspace);
+        } else if (keyEvent.key == Glfw.Key.GLFW_KEY_H && keyEvent.ctrlKey) {
+          App.dispatch(app, Backspace);
+        } else if (keyEvent.key == Glfw.Key.GLFW_KEY_ESCAPE) {
+          App.quit(0);
+        } else if (keyEvent.key == Glfw.Key.GLFW_KEY_W && keyEvent.ctrlKey) {
+          App.dispatch(app, ClearWord);
+        }
+      );
 
   let render = () => {
-      let state = App.getState(app);
+    let state = App.getState(app);
 
-      let filteredItems = filterItems(state.text, state.items);
-      let items =
-        List.map(
-          i => <text style=textHeaderStyle> {i.name} </text>,
-          filteredItems,
-        );
+    let filteredItems = filterItems(state.text, state.items);
+    let items =
+      List.map(
+        i => <text style=textHeaderStyle> {i.name} </text>,
+        filteredItems,
+      );
 
-        <view style={Style.make(~backgroundColor=Colors.blue, ~width, ())}>
-          <view style={Style.make(~height=50, ())}>
-            <text style=textHeaderStyle> {state.text ++ "|"} </text>
-          </view>
-          <view style={Style.make()}> ...items </view>
-        </view>
+    <view style={Style.make(~backgroundColor=Colors.blue, ~width, ())}>
+      <view style={Style.make(~height=50, ())}>
+        <text style=textHeaderStyle> {state.text ++ "|"} </text>
+      </view>
+      <view style={Style.make()> ...items </view>
+    </view>;
   };
 
   UI.start(~createOptions={autoSize: true}, w, render);

--- a/examples/Autocomplete.re
+++ b/examples/Autocomplete.re
@@ -159,7 +159,7 @@ let init = app => {
       <view style={Style.make(~height=50, ())}>
         <text style=textHeaderStyle> {state.text ++ "|"} </text>
       </view>
-      <view style={Style.make()> ...items </view>
+      <view style={Style.make()}> ...items </view>
     </view>;
   };
 

--- a/examples/Autocomplete.re
+++ b/examples/Autocomplete.re
@@ -111,8 +111,6 @@ let init = app => {
   );
   Window.show(w);
 
-  let ui = UI.create(w, ~createOptions={autoSize: true});
-
   let textHeaderStyle =
     Style.make(
       ~backgroundColor=Colors.black,
@@ -146,10 +144,7 @@ let init = app => {
       }
     );
 
-  /* Render function - where the magic happens! */
-  Window.setRenderCallback(
-    w,
-    () => {
+  let render = () => {
       let state = App.getState(app);
 
       let filteredItems = filterItems(state.text, state.items);
@@ -159,17 +154,15 @@ let init = app => {
           filteredItems,
         );
 
-      UI.render(
-        ui,
         <view style={Style.make(~backgroundColor=Colors.blue, ~width, ())}>
           <view style={Style.make(~height=50, ())}>
             <text style=textHeaderStyle> {state.text ++ "|"} </text>
           </view>
           <view style={Style.make()}> ...items </view>
-        </view>,
-      );
-    },
-  );
+        </view>
+  };
+
+  UI.start(~createOptions={autoSize: true}, w, render);
 };
 
 App.startWithState(initialState, reducer, init);

--- a/examples/Bin.re
+++ b/examples/Bin.re
@@ -92,13 +92,9 @@ module AnimatedText = (
 );
 
 let init = app => {
-  let w = App.createWindow(app, "Welcome to Revery!");
+  let win = App.createWindow(app, "Welcome to Revery!");
 
-  let ui = UI.create(w);
-
-  Window.setRenderCallback(w, () =>
-    UI.render(
-      ui,
+  let render = () => {
       <view
         style={Style.make(
           ~position=LayoutTypes.Absolute,
@@ -117,9 +113,10 @@ let init = app => {
           <AnimatedText delay=0.5 textContent="to" />
           <AnimatedText delay=1. textContent="Revery" />
         </view>
-      </view>,
-    )
-  );
+      </view>
+  };
+
+  UI.start(win, render);
 };
 
 App.start(init);

--- a/examples/Bin.re
+++ b/examples/Bin.re
@@ -94,27 +94,26 @@ module AnimatedText = (
 let init = app => {
   let win = App.createWindow(app, "Welcome to Revery!");
 
-  let render = () => {
+  let render = () =>
+    <view
+      style={Style.make(
+        ~position=LayoutTypes.Absolute,
+        ~justifyContent=LayoutTypes.JustifyCenter,
+        ~alignItems=LayoutTypes.AlignCenter,
+        ~bottom=0,
+        ~top=0,
+        ~left=0,
+        ~right=0,
+        (),
+      )}>
+      <Logo />
       <view
-        style={Style.make(
-          ~position=LayoutTypes.Absolute,
-          ~justifyContent=LayoutTypes.JustifyCenter,
-          ~alignItems=LayoutTypes.AlignCenter,
-          ~bottom=0,
-          ~top=0,
-          ~left=0,
-          ~right=0,
-          (),
-        )}>
-        <Logo />
-        <view
-          style={Style.make(~flexDirection=Row, ~alignItems=AlignFlexEnd, ())}>
-          <AnimatedText delay=0.0 textContent="Welcome" />
-          <AnimatedText delay=0.5 textContent="to" />
-          <AnimatedText delay=1. textContent="Revery" />
-        </view>
+        style={Style.make(~flexDirection=Row, ~alignItems=AlignFlexEnd, ())}>
+        <AnimatedText delay=0.0 textContent="Welcome" />
+        <AnimatedText delay=0.5 textContent="to" />
+        <AnimatedText delay=1. textContent="Revery" />
       </view>
-  };
+    </view>;
 
   UI.start(win, render);
 };

--- a/examples/Flexbox.re
+++ b/examples/Flexbox.re
@@ -104,46 +104,38 @@ let init = app => {
     <view>
       <text style=headerStyle> "Flex Direction Column" </text>
       <view
-        style={
-          parentStyles(
-            ~direction=LayoutTypes.Column,
-            ~justify=LayoutTypes.JustifyFlexStart,
-            (),
-          )
-        }>
+        style={parentStyles(
+          ~direction=LayoutTypes.Column,
+          ~justify=LayoutTypes.JustifyFlexStart,
+          (),
+        )}>
         <view style=childStyles>
           <text style=defaultTextStyles> "Align Flex Start" </text>
         </view>
       </view>
       <view
-        style={
-          parentStyles(
-            ~direction=LayoutTypes.Column,
-            ~justify=LayoutTypes.JustifyCenter,
-            (),
-          )
-        }>
+        style={parentStyles(
+          ~direction=LayoutTypes.Column,
+          ~justify=LayoutTypes.JustifyCenter,
+          (),
+        )}>
         <view style=childStyles>
           <text style=defaultTextStyles> "Align Flex Center" </text>
         </view>
       </view>
       <view
-        style={
-          parentStyles(
-            ~direction=LayoutTypes.Column,
-            ~justify=LayoutTypes.JustifyFlexEnd,
-            (),
-          )
-        }>
+        style={parentStyles(
+          ~direction=LayoutTypes.Column,
+          ~justify=LayoutTypes.JustifyFlexEnd,
+          (),
+        )}>
         <view style=childStyles>
           <text style=defaultTextStyles> "Align Flex End" </text>
         </view>
       </view>
     </view>;
 
-  let render = () => {
-    <view> horizontalStyles verticalStyles </view>
-  };
+  let render = () => <view> horizontalStyles verticalStyles </view>;
 
   UI.start(w, render);
 };

--- a/examples/Flexbox.re
+++ b/examples/Flexbox.re
@@ -17,8 +17,6 @@ let init = app => {
 
   Window.setPos(w, centerX, 0);
 
-  let ui = UI.create(w);
-
   let parentWidth = width - 5;
   let childWidth = width - 50;
 
@@ -143,9 +141,11 @@ let init = app => {
       </view>
     </view>;
 
-  Window.setRenderCallback(w, () =>
-    UI.render(ui, <view> horizontalStyles verticalStyles </view>)
-  );
+  let render = () => {
+    <view> horizontalStyles verticalStyles </view>
+  };
+
+  UI.start(w, render);
 };
 
 App.start(init);

--- a/src/UI/Revery_UI.re
+++ b/src/UI/Revery_UI.re
@@ -113,19 +113,22 @@ let _render = (container: uiContainer, component: UiReact.component) => {
   });
 };
 
-let start = (~createOptions=defaultUiContainerOptions, window: Window.t, render: renderFunction) => {
+let start =
+    (
+      ~createOptions=defaultUiContainerOptions,
+      window: Window.t,
+      render: renderFunction,
+    ) => {
   let rootNode = (new viewNode)();
   let container = UiReact.createContainer(rootNode);
-  let ui: uiContainer = {
-    window,
-    rootNode,
-    container,
-    options: createOptions,
-  };
+  let ui: uiContainer = {window, rootNode, container, options: createOptions};
 
   Window.setShouldRenderCallback(window, () => Animated.anyActiveAnimations());
-  Window.setRenderCallback(window, () => {
+  Window.setRenderCallback(
+    window,
+    () => {
       let component = render();
-      _render(ui, component)
-  });
+      _render(ui, component);
+    },
+  );
 };

--- a/src/UI/Revery_UI.re
+++ b/src/UI/Revery_UI.re
@@ -47,23 +47,11 @@ type uiContainer = {
   options: uiContainerOptions,
 };
 
-let create = (~createOptions=defaultUiContainerOptions, window: Window.t) => {
-  let rootNode = (new viewNode)();
-  let container = UiReact.createContainer(rootNode);
-  let ret: uiContainer = {
-    window,
-    rootNode,
-    container,
-    options: createOptions,
-  };
-
-  Window.setShouldRenderCallback(window, () => Animated.anyActiveAnimations());
-  ret;
-};
+type renderFunction = unit => UiReact.component;
 
 let _projection = Mat4.create();
 
-let render = (container: uiContainer, component: UiReact.component) => {
+let _render = (container: uiContainer, component: UiReact.component) => {
   let {rootNode, container, window, options} = container;
 
   AnimationTicker.tick();
@@ -122,5 +110,22 @@ let render = (container: uiContainer, component: UiReact.component) => {
     glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
     rootNode#draw(alphaPass, drawContext);
     glDisable(GL_BLEND);
+  });
+};
+
+let start = (~createOptions=defaultUiContainerOptions, window: Window.t, render: renderFunction) => {
+  let rootNode = (new viewNode)();
+  let container = UiReact.createContainer(rootNode);
+  let ui: uiContainer = {
+    window,
+    rootNode,
+    container,
+    options: createOptions,
+  };
+
+  Window.setShouldRenderCallback(window, () => Animated.anyActiveAnimations());
+  Window.setRenderCallback(window, () => {
+      let component = render();
+      _render(ui, component)
   });
 };


### PR DESCRIPTION
__Issue:__ Spinning up a UI is too complicated. Consumers of `revery` shouldn't need to know / care about the under-the-hood render callback provided by `glfw`.

__Fix:__ Consolidate `UI.create`/`UI.render` into `UI.start`, which just takes a callback that returns UI components.

Some things to think about in the future - do we want to pass any context in this render callback? For example - current app state, viewport / window dimensions, etc? All of this is accessible via the closure but perhaps there are some benefits to encapsulating these as args.