### PR TITLE
Animation - Bug: Fix timing when delay is present

### DIFF
--- a/examples/Bin.re
+++ b/examples/Bin.re
@@ -64,10 +64,10 @@ module AnimatedText = (
 
             let translate: float =
               useAnimation(
-                Animated.floatValue(100.),
+                Animated.floatValue(50.),
                 {
                   toValue: 0.,
-                  duration: Seconds(2.),
+                  duration: Seconds(0.5),
                   delay: Seconds(delay),
                   repeat: false,
                 },

--- a/src/UI/Animation.re
+++ b/src/UI/Animation.re
@@ -38,7 +38,7 @@ module Make = (AnimationTickerImpl: AnimationTicker) => {
 
   let getLocalTime = (clock: float, anim: animation) => {
     let adjustedStart = anim.startTime +. anim.delay;
-    let endTime = anim.startTime +. anim.duration;
+    let endTime = adjustedStart +. anim.duration;
     (clock -. adjustedStart) /. (endTime -. adjustedStart);
   };
 

--- a/test/UI/AnimationTest.re
+++ b/test/UI/AnimationTest.re
@@ -67,6 +67,26 @@ test("Animation", () => {
     expect(myAnimation.value.current).toBe(5.);
   });
 
+  test("animation with delay", () => {
+    module TestTicker =
+      MakeTicker({});
+    module Animated = Animation.Make(TestTicker);
+
+    let myAnimation =
+      Animated.start(
+        Animated.floatValue(0.),
+        {
+          duration: Time.Seconds(2.),
+          delay: Time.Seconds(1.),
+          toValue: 10.,
+          repeat: false,
+        },
+      );
+
+    TestTicker.simulateTick(Time.Seconds(2.));
+    expect(myAnimation.value.current).toBe(5.);
+  });
+
   test("animations are cleaned up", () => {
     module TestTicker =
       MakeTicker({});


### PR DESCRIPTION
__Issue:__ The `delay` for an animation wasn't being accounted for correctly. We weren't including the `delay` in the `endTime` calculation, so the animation would just end up being shortened by the dealy.

__Fix:__ Incorporate delay in local time calculation. Add test that exercises bug.