### PR TITLE
#38 - Part 2 - Hook up some basic mouseup/mousedown/mousemove events

### DIFF
--- a/examples/Autocomplete.re
+++ b/examples/Autocomplete.re
@@ -129,18 +129,17 @@ let init = app => {
 
   /* Listen to key down events, and coerce them into actions, too */
   let _ =
-    Event.subscribe(w.onKeyDown, keyEvent
-      =>
-        if (keyEvent.key == Key.KEY_BACKSPACE) {
-          App.dispatch(app, Backspace);
-        } else if (keyEvent.key == Key.KEY_H && keyEvent.ctrlKey) {
-          App.dispatch(app, Backspace);
-        } else if (keyEvent.key == Key.KEY_ESCAPE) {
-          App.quit(0);
-        } else if (keyEvent.key == Key.KEY_W && keyEvent.ctrlKey) {
-          App.dispatch(app, ClearWord);
-        }
-      );
+    Event.subscribe(w.onKeyDown, keyEvent =>
+      if (keyEvent.key == Key.KEY_BACKSPACE) {
+        App.dispatch(app, Backspace);
+      } else if (keyEvent.key == Key.KEY_H && keyEvent.ctrlKey) {
+        App.dispatch(app, Backspace);
+      } else if (keyEvent.key == Key.KEY_ESCAPE) {
+        App.quit(0);
+      } else if (keyEvent.key == Key.KEY_W && keyEvent.ctrlKey) {
+        App.dispatch(app, ClearWord);
+      }
+    );
 
   let render = () => {
     let state = App.getState(app);
@@ -156,7 +155,7 @@ let init = app => {
       <view style={Style.make(~height=50, ())}>
         <text style=textHeaderStyle> {state.text ++ "|"} </text>
       </view>
-      <view style={Style.make()}> ...items </view>
+      <view style={Style.make()> ...items </view>
     </view>;
   };
 

--- a/examples/Autocomplete.re
+++ b/examples/Autocomplete.re
@@ -129,17 +129,18 @@ let init = app => {
 
   /* Listen to key down events, and coerce them into actions, too */
   let _ =
-    Event.subscribe(w.onKeyDown, keyEvent =>
-      if (keyEvent.key == Key.KEY_BACKSPACE) {
-        App.dispatch(app, Backspace);
-      } else if (keyEvent.key == Key.KEY_H && keyEvent.ctrlKey) {
-        App.dispatch(app, Backspace);
-      } else if (keyEvent.key == Key.KEY_ESCAPE) {
-        App.quit(0);
-      } else if (keyEvent.key == Key.KEY_W && keyEvent.ctrlKey) {
-        App.dispatch(app, ClearWord);
-      }
-    );
+    Event.subscribe(w.onKeyDown, keyEvent
+      =>
+        if (keyEvent.key == Key.KEY_BACKSPACE) {
+          App.dispatch(app, Backspace);
+        } else if (keyEvent.key == Key.KEY_H && keyEvent.ctrlKey) {
+          App.dispatch(app, Backspace);
+        } else if (keyEvent.key == Key.KEY_ESCAPE) {
+          App.quit(0);
+        } else if (keyEvent.key == Key.KEY_W && keyEvent.ctrlKey) {
+          App.dispatch(app, ClearWord);
+        }
+      );
 
   let render = () => {
     let state = App.getState(app);
@@ -155,7 +156,7 @@ let init = app => {
       <view style={Style.make(~height=50, ())}>
         <text style=textHeaderStyle> {state.text ++ "|"} </text>
       </view>
-      <view style={Style.make()> ...items </view>
+      <view style={Style.make()}> ...items </view>
     </view>;
   };
 

--- a/examples/Bin.re
+++ b/examples/Bin.re
@@ -9,8 +9,8 @@ module Logo = (
           () => {
             let (opacity, setOpacity) = useState(1.0);
 
-            let onMouseDown = (_) => { setOpacity(0.5); };
-            let onMouseUp = (_) => { setOpacity(1.0); };
+            let onMouseDown = _ => setOpacity(0.5);
+            let onMouseUp = _ => setOpacity(1.0);
 
             let rotation =
               useAnimation(
@@ -35,19 +35,20 @@ module Logo = (
               );
 
             <view onMouseDown onMouseUp>
-            <image
-              src="outrun-logo.png"
-              style={Style.make(
-                ~width=512,
-                ~height=256,
-                ~opacity=opacity,
-                ~transform=[
-                  RotateY(Angle.from_radians(rotationY)),
-                  RotateX(Angle.from_radians(rotation)),
-                ],
-                (),
-              )}
-            /></view>;
+              <image
+                src="outrun-logo.png"
+                style={Style.make(
+                  ~width=512,
+                  ~height=256,
+                  ~opacity,
+                  ~transform=[
+                    RotateY(Angle.from_radians(rotationY)),
+                    RotateX(Angle.from_radians(rotation)),
+                  ],
+                  (),
+                )}
+              />
+            </view>;
           },
           ~children,
         )

--- a/examples/Bin.re
+++ b/examples/Bin.re
@@ -9,8 +9,8 @@ module Logo = (
           () => {
             let (opacity, setOpacity) = useState(1.0);
 
-            let onMouseDown = (_) => { setOpacity(0.5); NodeEvents.Continue; };
-            let onMouseUp = (_) => { setOpacity(1.0); NodeEvents.Continue; };
+            let onMouseDown = (_) => { setOpacity(0.5); };
+            let onMouseUp = (_) => { setOpacity(1.0); };
 
             let rotation =
               useAnimation(

--- a/examples/Bin.re
+++ b/examples/Bin.re
@@ -7,6 +7,11 @@ module Logo = (
   val component((render, ~children, ()) =>
         render(
           () => {
+            let (opacity, setOpacity) = useState(1.0);
+
+            let onMouseDown = (_) => { setOpacity(0.5); NodeEvents.Continue; };
+            let onMouseUp = (_) => { setOpacity(1.0); NodeEvents.Continue; };
+
             let rotation =
               useAnimation(
                 Animated.floatValue(0.),
@@ -29,18 +34,20 @@ module Logo = (
                 },
               );
 
+            <view onMouseDown onMouseUp>
             <image
               src="outrun-logo.png"
               style={Style.make(
                 ~width=512,
                 ~height=256,
+                ~opacity=opacity,
                 ~transform=[
                   RotateY(Angle.from_radians(rotationY)),
                   RotateX(Angle.from_radians(rotation)),
                 ],
                 (),
               )}
-            />;
+            /></view>;
           },
           ~children,
         )
@@ -94,21 +101,6 @@ module AnimatedText = (
 let init = app => {
   let win = App.createWindow(app, "Welcome to Revery!");
 
-  let onMouseMove = (_evt) => {
-    print_endline ("mouse move over view"); 
-    NodeEvents.Continue;
-  };
-
-  let onMouseDown = (_evt) => {
-    print_endline ("mouse down!"); 
-    NodeEvents.Continue;
-  };
-
-  let onMouseUp = (_evt) => {
-    print_endline ("mouse up!");
-    NodeEvents.Continue;
-  };
-
   let render = () =>
     <view
       style={Style.make(
@@ -122,7 +114,7 @@ let init = app => {
         (),
       )}>
       <Logo />
-      <view onMouseMove onMouseDown onMouseUp
+      <view
         style={Style.make(~flexDirection=Row, ~alignItems=AlignFlexEnd, ())}>
         <AnimatedText delay=0.0 textContent="Welcome" />
         <AnimatedText delay=0.5 textContent="to" />

--- a/examples/Bin.re
+++ b/examples/Bin.re
@@ -94,6 +94,21 @@ module AnimatedText = (
 let init = app => {
   let win = App.createWindow(app, "Welcome to Revery!");
 
+  let onMouseMove = (_evt) => {
+    print_endline ("mouse move over view"); 
+    NodeEvents.Continue;
+  };
+
+  let onMouseDown = (_evt) => {
+    print_endline ("mouse down!"); 
+    NodeEvents.Continue;
+  };
+
+  let onMouseUp = (_evt) => {
+    print_endline ("mouse up!");
+    NodeEvents.Continue;
+  };
+
   let render = () =>
     <view
       style={Style.make(
@@ -107,7 +122,7 @@ let init = app => {
         (),
       )}>
       <Logo />
-      <view
+      <view onMouseMove onMouseDown onMouseUp
         style={Style.make(~flexDirection=Row, ~alignItems=AlignFlexEnd, ())}>
         <AnimatedText delay=0.0 textContent="Welcome" />
         <AnimatedText delay=0.5 textContent="to" />

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "reason-glfw": "^3.2.1005",
     "reason-fontkit": "^1.1.0",
     "reason-gl-matrix": "^0.2.0",
-    "reason-reactify": "^2.1.0",
+    "reason-reactify": "^2.2.0",
     "@opam/color": "^0.2.0",
     "@opam/lwt": "^4.0.0",
     "@opam/lwt_ppx": "^1.1.0",

--- a/src/Core/Color_wrapper.re
+++ b/src/Core/Color_wrapper.re
@@ -2,29 +2,19 @@ open Reglm;
 
 type t = Color.Rgba'.t;
 
-let rgba = (r, g, b, a) =>  {
-    Color.of_rgba'(r, g, b, a)
-    |> Color.to_rgba';
-};
+let rgba = (r, g, b, a) => Color.of_rgba'(r, g, b, a) |> Color.to_rgba';
 
-let rgb = (r, g, b) => {
-    Color.of_rgb'(r, g, b)
-    |> Color.to_rgba';
-};
+let rgb = (r, g, b) => Color.of_rgb'(r, g, b) |> Color.to_rgba';
 
 exception ColorHexParseException(string);
 
-let parseOrThrow = (str, c) => {
-    switch (c) {
-    | Some(v) => v
-    | None => raise(ColorHexParseException("Unable to parse color: " ++ str))
-    };
-};
+let parseOrThrow = (str, c) =>
+  switch (c) {
+  | Some(v) => v
+  | None => raise(ColorHexParseException("Unable to parse color: " ++ str))
+  };
 
-let hex = c => c 
-    |> Color.of_hexstring
-    |> parseOrThrow(c)
-    |> Color.to_rgba';
+let hex = c => c |> Color.of_hexstring |> parseOrThrow(c) |> Color.to_rgba';
 
 let multiplyAlpha = (opacity: float, color: t) => {
   let ret: t = {...color, a: opacity *. color.a};

--- a/src/Core/Events.re
+++ b/src/Core/Events.re
@@ -1,0 +1,24 @@
+type keyPressEvent = {
+  codepoint: int,
+  character: string,
+};
+
+type keyEvent = {
+  key: Key.t,
+  scancode: int,
+  altKey: bool,
+  ctrlKey: bool,
+  shiftKey: bool,
+  superKey: bool,
+  isRepeat: bool,
+};
+
+type mouseMoveEvent = {
+  mouseX: float,
+  mouseY: float,
+};
+
+type mouseButtonEvent = {
+  button: MouseButton.t,
+};
+

--- a/src/Core/Events.re
+++ b/src/Core/Events.re
@@ -22,3 +22,7 @@ type mouseButtonEvent = {
   button: MouseButton.t,
 };
 
+type internalMouseEvents = 
+| InternalMouseDown(mouseButtonEvent)
+| InternalMouseMove(mouseMoveEvent)
+| InternalMouseUp(mouseButtonEvent);

--- a/src/Core/Events.re
+++ b/src/Core/Events.re
@@ -18,11 +18,9 @@ type mouseMoveEvent = {
   mouseY: float,
 };
 
-type mouseButtonEvent = {
-  button: MouseButton.t,
-};
+type mouseButtonEvent = {button: MouseButton.t};
 
-type internalMouseEvents = 
-| InternalMouseDown(mouseButtonEvent)
-| InternalMouseMove(mouseMoveEvent)
-| InternalMouseUp(mouseButtonEvent);
+type internalMouseEvents =
+  | InternalMouseDown(mouseButtonEvent)
+  | InternalMouseMove(mouseMoveEvent)
+  | InternalMouseUp(mouseButtonEvent);

--- a/src/Core/MouseButton.re
+++ b/src/Core/MouseButton.re
@@ -1,0 +1,15 @@
+open Reglfw.Glfw.MouseButton;
+
+type t =
+  | BUTTON_LEFT
+  | BUTTON_MIDDLE
+  | BUTTON_RIGHT
+  | BUTTON_UNKNOWN;
+
+let convert = glfwButton =>
+  switch (glfwButton) {
+  | GLFW_MOUSE_LEFT => BUTTON_LEFT
+  | GLFW_MOUSE_MIDDLE => BUTTON_MIDDLE
+  | GLFW_MOUSE_RIGHT => BUTTON_RIGHT
+  | _ => BUTTON_UNKNOWN
+  };

--- a/src/Core/MouseButton.rei
+++ b/src/Core/MouseButton.rei
@@ -1,0 +1,7 @@
+type t =
+  | BUTTON_LEFT
+  | BUTTON_MIDDLE
+  | BUTTON_RIGHT
+  | BUTTON_UNKNOWN
+
+let convert: Reglfw.Glfw.MouseButton.t => t;

--- a/src/Core/Revery_Core.re
+++ b/src/Core/Revery_Core.re
@@ -1,6 +1,7 @@
 module Color = Color_wrapper;
 module Colors = Colors;
 module Key = Key;
+module MouseButton = MouseButton;
 
 module Window = Window;
 module App = App;
@@ -10,6 +11,7 @@ module Monitor = Monitor;
 module Environment = Environment;
 
 module Event = Reactify.Event;
+module Events = Events;
 
 module Performance = Performance;
 

--- a/src/Core/Window.re
+++ b/src/Core/Window.re
@@ -240,25 +240,22 @@ let create = (name: string, options: windowCreateOptions) => {
   Glfw.glfwSetMouseButtonCallback(
     w,
     (_w, mouseButton, buttonState, _modifier) => {
-        let evt: mouseButtonEvent = { button: MouseButton.convert(mouseButton) };
-       switch(buttonState) {
-       | GLFW_PRESS => Event.dispatch(ret.onMouseDown, evt)
-       | GLFW_REPEAT => Event.dispatch(ret.onMouseDown, evt)
-       | GLFW_RELEASE => Event.dispatch(ret.onMouseUp, evt)
-       };
-    }
+      let evt: mouseButtonEvent = {button: MouseButton.convert(mouseButton)};
+      switch (buttonState) {
+      | GLFW_PRESS => Event.dispatch(ret.onMouseDown, evt)
+      | GLFW_REPEAT => Event.dispatch(ret.onMouseDown, evt)
+      | GLFW_RELEASE => Event.dispatch(ret.onMouseUp, evt)
+      };
+    },
   );
 
   Glfw.glfwSetCursorPosCallback(
     w,
     (_w, x: float, y: float) => {
-        let evt: mouseMoveEvent = {
-            mouseX: x,
-            mouseY: y,
-        };
+      let evt: mouseMoveEvent = {mouseX: x, mouseY: y};
 
-        Event.dispatch(ret.onMouseMove, evt);
-    }
+      Event.dispatch(ret.onMouseMove, evt);
+    },
   );
   ret;
 };

--- a/src/Core/Window.re
+++ b/src/Core/Window.re
@@ -3,25 +3,7 @@ open Reglfw;
 module Event = Reactify.Event;
 module Color = Color_wrapper;
 
-type keyPressEvent = {
-  codepoint: int,
-  character: string,
-};
-
-type keyEvent = {
-  key: Key.t,
-  scancode: int,
-  altKey: bool,
-  ctrlKey: bool,
-  shiftKey: bool,
-  superKey: bool,
-  isRepeat: bool,
-};
-
-type mouseMoveEvent = {
-  mouseX: float,
-  mouseY: float,
-};
+open Events;
 
 type windowRenderCallback = unit => unit;
 type windowShouldRenderCallback = unit => bool;
@@ -44,7 +26,9 @@ type t = {
   onKeyPress: Event.t(keyPressEvent),
   onKeyDown: Event.t(keyEvent),
   onKeyUp: Event.t(keyEvent),
+  onMouseUp: Event.t(mouseButtonEvent),
   onMouseMove: Event.t(mouseMoveEvent),
+  onMouseDown: Event.t(mouseButtonEvent),
 };
 
 type windowCreateOptions = {
@@ -168,7 +152,10 @@ let create = (name: string, options: windowCreateOptions) => {
     onKeyPress: Event.create(),
     onKeyDown: Event.create(),
     onKeyUp: Event.create(),
+
     onMouseMove: Event.create(),
+    onMouseUp: Event.create(),
+    onMouseDown: Event.create(),
   };
 
   Glfw.glfwSetFramebufferSizeCallback(
@@ -248,6 +235,18 @@ let create = (name: string, options: windowCreateOptions) => {
       | GLFW_RELEASE => Event.dispatch(ret.onKeyUp, evt)
       };
     },
+  );
+
+  Glfw.glfwSetMouseButtonCallback(
+    w,
+    (_w, mouseButton, buttonState, _modifier) => {
+        let evt: mouseButtonEvent = { button: MouseButton.convert(mouseButton) };
+       switch(buttonState) {
+       | GLFW_PRESS => Event.dispatch(ret.onMouseDown, evt)
+       | GLFW_REPEAT => Event.dispatch(ret.onMouseDown, evt)
+       | GLFW_RELEASE => Event.dispatch(ret.onMouseUp, evt)
+       };
+    }
   );
 
   Glfw.glfwSetCursorPosCallback(

--- a/src/Core/Window.re
+++ b/src/Core/Window.re
@@ -18,6 +18,11 @@ type keyEvent = {
   isRepeat: bool,
 };
 
+type mouseMoveEvent = {
+  mouseX: float,
+  mouseY: float,
+};
+
 type windowRenderCallback = unit => unit;
 type windowShouldRenderCallback = unit => bool;
 type t = {
@@ -39,6 +44,7 @@ type t = {
   onKeyPress: Event.t(keyPressEvent),
   onKeyDown: Event.t(keyEvent),
   onKeyUp: Event.t(keyEvent),
+  onMouseMove: Event.t(mouseMoveEvent),
 };
 
 type windowCreateOptions = {
@@ -162,6 +168,7 @@ let create = (name: string, options: windowCreateOptions) => {
     onKeyPress: Event.create(),
     onKeyDown: Event.create(),
     onKeyUp: Event.create(),
+    onMouseMove: Event.create(),
   };
 
   Glfw.glfwSetFramebufferSizeCallback(
@@ -241,6 +248,18 @@ let create = (name: string, options: windowCreateOptions) => {
       | GLFW_RELEASE => Event.dispatch(ret.onKeyUp, evt)
       };
     },
+  );
+
+  Glfw.glfwSetCursorPosCallback(
+    w,
+    (_w, x: float, y: float) => {
+        let evt: mouseMoveEvent = {
+            mouseX: x,
+            mouseY: y,
+        };
+
+        Event.dispatch(ret.onMouseMove, evt);
+    }
   );
   ret;
 };

--- a/src/UI/Layout.re
+++ b/src/UI/Layout.re
@@ -1,3 +1,5 @@
+open Revery_Core;
+
 open Flex;
 
 module Node = {
@@ -30,13 +32,15 @@ let createNodeWithMeasure = (children, style, measure) =>
     rootContext,
   );
 let layout = (node, pixelRatio) => {
-  let layoutNode = node#toLayoutNode(pixelRatio);
-  Layout.layoutNode(
-    layoutNode,
-    Encoding.cssUndefined,
-    Encoding.cssUndefined,
-    Ltr,
-  );
+  Performance.bench("layout", () => {
+      let layoutNode = node#toLayoutNode(pixelRatio);
+      Layout.layoutNode(
+        layoutNode,
+        Encoding.cssUndefined,
+        Encoding.cssUndefined,
+        Ltr,
+      );
+  });
 };
 let printCssNode = root =>
   LayoutPrint.printCssNode((

--- a/src/UI/Layout.re
+++ b/src/UI/Layout.re
@@ -31,17 +31,16 @@ let createNodeWithMeasure = (children, style, measure) =>
     ~andMeasure=measure,
     rootContext,
   );
-let layout = (node, pixelRatio) => {
+let layout = (node, pixelRatio) =>
   Performance.bench("layout", () => {
-      let layoutNode = node#toLayoutNode(pixelRatio);
-      Layout.layoutNode(
-        layoutNode,
-        Encoding.cssUndefined,
-        Encoding.cssUndefined,
-        Ltr,
-      );
+    let layoutNode = node#toLayoutNode(pixelRatio);
+    Layout.layoutNode(
+      layoutNode,
+      Encoding.cssUndefined,
+      Encoding.cssUndefined,
+      Ltr,
+    );
   });
-};
 let printCssNode = root =>
   LayoutPrint.printCssNode((
     root,

--- a/src/UI/Mouse.re
+++ b/src/UI/Mouse.re
@@ -61,11 +61,7 @@ let dispatch = (cursor: Cursor.t, evt: Events.internalMouseEvents, node: Node.no
    };
 
    Node.iter(collect, node);
-
-   print_endline ("dispatch - " ++ string_of_int(List.length(nodes^)) ++ " impacted");
-
    List.iter((n) => n#handleEvent(eventToSend), nodes^);
-
    Cursor.set(cursor, pos);
 };
 

--- a/src/UI/Mouse.re
+++ b/src/UI/Mouse.re
@@ -4,64 +4,58 @@ open Revery_Math;
 
 open NodeEvents;
 
-module Cursor {
+module Cursor = {
+  /* State needed to track on the cursor */
+  type t = {
+    x: ref(float),
+    y: ref(float),
+  };
 
-    /* State needed to track on the cursor */
-    type t = {
-        x: ref(float),
-        y: ref(float),
-    };
+  let make = () => {
+    let ret: t = {x: ref(0.), y: ref(0.)};
+    ret;
+  };
 
-    let make = () => {
-        let ret: t = {
-            x: ref(0.),
-            y: ref(0.),
-        };
-        ret;
-    };
+  let toVec2 = c => Vec2.create(c.x^, c.y^);
 
-    let toVec2 = (c) => {
-        Vec2.create(c.x^, c.y^)
-    };
-
-    let set = (c, v: Vec2.t) => {
-        c.x := Vec2.get_x(v); 
-        c.y := Vec2.get_y(v); 
-    }
-}
-
-let getPositionFromMouseEvent = (c: Cursor.t, evt: Events.internalMouseEvents) => {
-    switch (evt) {
-    | InternalMouseDown(_) => Cursor.toVec2(c)
-    | InternalMouseMove(e) => Vec2.create(e.mouseX, e.mouseY)
-    | InternalMouseUp(_) => Cursor.toVec2(c)
-    }
-}
-
-let internalToExternalEvent = (c: Cursor.t, evt: Events.internalMouseEvents) => {
-   switch (evt) {
-   | InternalMouseDown(evt) => MouseDown({mouseX: c.x^, mouseY: c.y^, button: evt.button})
-   | InternalMouseUp(evt) => MouseUp({mouseX: c.x^, mouseY: c.y^, button: evt.button})
-   | InternalMouseMove(evt) => MouseMove({mouseX: evt.mouseX, mouseY: evt.mouseY})
-   };
+  let set = (c, v: Vec2.t) => {
+    c.x := Vec2.get_x(v);
+    c.y := Vec2.get_y(v);
+  };
 };
 
-let dispatch = (cursor: Cursor.t, evt: Events.internalMouseEvents, node: Node.node('a)) => {
-   let pos = getPositionFromMouseEvent(cursor, evt);
+let getPositionFromMouseEvent = (c: Cursor.t, evt: Events.internalMouseEvents) =>
+  switch (evt) {
+  | InternalMouseDown(_) => Cursor.toVec2(c)
+  | InternalMouseMove(e) => Vec2.create(e.mouseX, e.mouseY)
+  | InternalMouseUp(_) => Cursor.toVec2(c)
+  };
 
-   let eventToSend = internalToExternalEvent(cursor, evt);
+let internalToExternalEvent = (c: Cursor.t, evt: Events.internalMouseEvents) =>
+  switch (evt) {
+  | InternalMouseDown(evt) =>
+    MouseDown({mouseX: c.x^, mouseY: c.y^, button: evt.button})
+  | InternalMouseUp(evt) =>
+    MouseUp({mouseX: c.x^, mouseY: c.y^, button: evt.button})
+  | InternalMouseMove(evt) =>
+    MouseMove({mouseX: evt.mouseX, mouseY: evt.mouseY})
+  };
 
-   let isNodeImpacted = (n) => n#hitTest(pos); 
+let dispatch =
+    (cursor: Cursor.t, evt: Events.internalMouseEvents, node: Node.node('a)) => {
+  let pos = getPositionFromMouseEvent(cursor, evt);
 
-   let nodes: ref(list(Node.node('a))) = ref([]);
-   let collect = (n) => {
-       if (isNodeImpacted(n)) {
-        nodes := List.append(nodes^, [n]);
-       }
-   };
+  let eventToSend = internalToExternalEvent(cursor, evt);
 
-   Node.iter(collect, node);
-   List.iter((n) => n#handleEvent(eventToSend), nodes^);
-   Cursor.set(cursor, pos);
+  let isNodeImpacted = n => n#hitTest(pos);
+
+  let nodes: ref(list(Node.node('a))) = ref([]);
+  let collect = n =>
+    if (isNodeImpacted(n)) {
+      nodes := List.append(nodes^, [n]);
+    };
+
+  Node.iter(collect, node);
+  List.iter(n => n#handleEvent(eventToSend), nodes^);
+  Cursor.set(cursor, pos);
 };
-

--- a/src/UI/Mouse.re
+++ b/src/UI/Mouse.re
@@ -1,0 +1,45 @@
+/* Mouse Input */
+open Revery_Math;
+
+open NodeEvents;
+
+module Cursor {
+
+    /* State needed to track on the cursor */
+    type t = {
+        x: ref(float),
+        y: ref(float),
+    };
+
+    let make = () => {
+        let ret: t = {
+            x: ref(0.),
+            y: ref(0.),
+        };
+        ret;
+    };
+}
+
+let getPositionFromMouseEvent = (evt: mouseEvent) => {
+    switch (evt) {
+    | MouseDown(c) => Vec2.create(c.xPos, c.yPos)
+    | MouseMove(c) => Vec2.create(c.xPos, c.yPos)
+    | MouseUp(c) => Vec2.create(c.xPos, c.yPos)
+    }
+}
+
+let dispatch = (_cursor: Cursor.t, evt: mouseEvent, node: Node.node('a)) => {
+   let pos =getPositionFromMouseEvent(evt);
+
+   let isNodeImpacted = (n) => n#hitTest(pos); 
+
+   let nodes: ref(list(Node.node('a))) = ref([]);
+   let collect = (n) => {
+       if (isNodeImpacted(n)) {
+        nodes := List.append(nodes^, [n]);
+       }
+   };
+
+   Node.iter(collect, node);
+};
+

--- a/src/UI/Mouse.re
+++ b/src/UI/Mouse.re
@@ -22,9 +22,9 @@ module Cursor {
 
 let getPositionFromMouseEvent = (evt: mouseEvent) => {
     switch (evt) {
-    | MouseDown(c) => Vec2.create(c.xPos, c.yPos)
-    | MouseMove(c) => Vec2.create(c.xPos, c.yPos)
-    | MouseUp(c) => Vec2.create(c.xPos, c.yPos)
+    | MouseDown(c) => Vec2.create(c.mouseX, c.mouseY)
+    | MouseMove(c) => Vec2.create(c.mouseX, c.mouseY)
+    | MouseUp(c) => Vec2.create(c.mouseX, c.mouseY)
     }
 }
 
@@ -41,5 +41,9 @@ let dispatch = (_cursor: Cursor.t, evt: mouseEvent, node: Node.node('a)) => {
    };
 
    Node.iter(collect, node);
+
+   print_endline ("dispatch - " ++ string_of_int(List.length(nodes^)) ++ " impacted");
+
+   List.iter((n) => n#handleEvent(evt), nodes^);
 };
 

--- a/src/UI/Node.re
+++ b/src/UI/Node.re
@@ -22,6 +22,7 @@ class node ('a) (()) = {
   pub setStyle = style => _style := style;
   pub getStyle = () => _style^;
   pub setEvents = events => _events := events;
+  pub getEvents = () => _events^;
   pub getTransform = () => {
     let dimensions = _layoutNode^.layout;
     let matrix = Mat4.create();
@@ -77,6 +78,12 @@ class node ('a) (()) = {
   pub getParent = () => _parent^;
   pub getChildren = () => _children^;
   pub getMeasureFunction = (_pixelRatio: int) => None;
+  pub handleEvent = (evt: NodeEvents.mouseEvent) => {
+    let _ = switch (evt) {
+    | MouseMove(c) => _this#getEvents().onMouseMove(c);
+    | _ => Continue;
+    };
+  };
   pub toLayoutNode = (pixelRatio: int) => {
     let childNodes = List.map(c => c#toLayoutNode(pixelRatio), _children^);
     let layoutStyle = Style.toLayoutNode(_style^, pixelRatio);

--- a/src/UI/Node.re
+++ b/src/UI/Node.re
@@ -80,8 +80,10 @@ class node ('a) (()) = {
   pub getMeasureFunction = (_pixelRatio: int) => None;
   pub handleEvent = (evt: NodeEvents.mouseEvent) => {
     let _ = switch (evt) {
+    | MouseDown(c) => _this#getEvents().onMouseDown(c);
     | MouseMove(c) => _this#getEvents().onMouseMove(c);
-    | _ => Continue;
+    | MouseUp(c) => _this#getEvents().onMouseUp(c);
+    /* | _ => Continue; */
     };
   };
   pub toLayoutNode = (pixelRatio: int) => {

--- a/src/UI/Node.re
+++ b/src/UI/Node.re
@@ -83,7 +83,6 @@ class node ('a) (()) = {
     | MouseDown(c) => _this#getEvents().onMouseDown(c);
     | MouseMove(c) => _this#getEvents().onMouseMove(c);
     | MouseUp(c) => _this#getEvents().onMouseUp(c);
-    /* | _ => Continue; */
     };
   };
   pub toLayoutNode = (pixelRatio: int) => {

--- a/src/UI/Node.re
+++ b/src/UI/Node.re
@@ -79,11 +79,13 @@ class node ('a) (()) = {
   pub getChildren = () => _children^;
   pub getMeasureFunction = (_pixelRatio: int) => None;
   pub handleEvent = (evt: NodeEvents.mouseEvent) => {
-    let _ = switch (evt) {
-    | MouseDown(c) => _this#getEvents().onMouseDown(c);
-    | MouseMove(c) => _this#getEvents().onMouseMove(c);
-    | MouseUp(c) => _this#getEvents().onMouseUp(c);
-    };
+    let _ =
+      switch (evt) {
+      | MouseDown(c) => _this#getEvents().onMouseDown(c)
+      | MouseMove(c) => _this#getEvents().onMouseMove(c)
+      | MouseUp(c) => _this#getEvents().onMouseUp(c)
+      };
+    ();
   };
   pub toLayoutNode = (pixelRatio: int) => {
     let childNodes = List.map(c => c#toLayoutNode(pixelRatio), _children^);
@@ -107,11 +109,11 @@ class node ('a) (()) = {
 };
 
 let iter = (f, node: node('a)) => {
-  let rec apply = (node) => {
+  let rec apply = node => {
     f(node);
 
     let children = node#getChildren();
-    List.iter(apply, children)
+    List.iter(apply, children);
   };
 
   apply(node);

--- a/src/UI/Node.re
+++ b/src/UI/Node.re
@@ -9,6 +9,7 @@ class node ('a) (()) = {
   as _this;
   val _children: ref(list(node('a))) = ref([]);
   val _style: ref(Style.t) = ref(Style.defaultStyle);
+  val _events: ref(NodeEvents.t) = ref(NodeEvents.default);
   val _layoutNode = ref(Layout.createNode([||], Layout.defaultStyle));
   val _parent: ref(option(node('a))) = ref(None);
   pub draw = (pass: 'a, parentContext: NodeDrawContext.t) => {
@@ -20,6 +21,7 @@ class node ('a) (()) = {
   pub measurements = () => _layoutNode^.layout;
   pub setStyle = style => _style := style;
   pub getStyle = () => _style^;
+  pub setEvents = events => _events := events;
   pub getTransform = () => {
     let dimensions = _layoutNode^.layout;
     let matrix = Mat4.create();
@@ -94,4 +96,15 @@ class node ('a) (()) = {
   };
   /* TODO: This should really be private - it should never be explicitly set */
   pub _setParent = (n: option(node('a))) => _parent := n;
+};
+
+let iter = (f, node: node('a)) => {
+  let rec apply = (node) => {
+    f(node);
+
+    let children = node#getChildren();
+    List.iter(apply, children)
+  };
+
+  apply(node);
 };

--- a/src/UI/NodeEvents.re
+++ b/src/UI/NodeEvents.re
@@ -2,21 +2,26 @@
 
 /* A collection of event handlers to be used by the Nodes */
 
+open Revery_Core;
+
 type eventResult =
 | Continue;
 
 type mouseMoveEventParams = {
-    mouseX: float,   
+    mouseX: float,
     mouseY: float,
 };
 
-type mouseButtonEventParams = mouseMoveEventParams;
+type mouseButtonEventParams = {
+    mouseX: float,
+    mouseY: float,
+    button: MouseButton.t,
+};
 
 type mouseEvent = 
 | MouseDown(mouseButtonEventParams)
 | MouseMove(mouseMoveEventParams)
-| MouseUp(mouseButtonEventParams)
-
+| MouseUp(mouseButtonEventParams);
 
 type mouseButtonHandler = (mouseButtonEventParams) => eventResult;
 type mouseMoveHandler = (mouseMoveEventParams) => eventResult;

--- a/src/UI/NodeEvents.re
+++ b/src/UI/NodeEvents.re
@@ -5,39 +5,41 @@
 open Revery_Core;
 
 type mouseMoveEventParams = {
-    mouseX: float,
-    mouseY: float,
+  mouseX: float,
+  mouseY: float,
 };
 
 type mouseButtonEventParams = {
-    mouseX: float,
-    mouseY: float,
-    button: MouseButton.t,
+  mouseX: float,
+  mouseY: float,
+  button: MouseButton.t,
 };
 
-type mouseEvent = 
-| MouseDown(mouseButtonEventParams)
-| MouseMove(mouseMoveEventParams)
-| MouseUp(mouseButtonEventParams);
+type mouseEvent =
+  | MouseDown(mouseButtonEventParams)
+  | MouseMove(mouseMoveEventParams)
+  | MouseUp(mouseButtonEventParams);
 
-type mouseButtonHandler = (mouseButtonEventParams) => unit;
-type mouseMoveHandler = (mouseMoveEventParams) => unit;
+type mouseButtonHandler = mouseButtonEventParams => unit;
+type mouseMoveHandler = mouseMoveEventParams => unit;
 
 type t = {
-    onMouseDown: mouseButtonHandler,
-    onMouseMove: mouseMoveHandler,
-    onMouseUp: mouseButtonHandler,
+  onMouseDown: mouseButtonHandler,
+  onMouseMove: mouseMoveHandler,
+  onMouseUp: mouseButtonHandler,
 };
 
-let eventNoop = (_evt) => ();
+let eventNoop = _evt => ();
 
-let make = (~onMouseDown: mouseButtonHandler=eventNoop,~onMouseMove:mouseMoveHandler=eventNoop, ~onMouseUp:mouseButtonHandler=eventNoop, _unit: unit) => {
-    let ret: t = {
-        onMouseDown,
-        onMouseMove,
-        onMouseUp,
-    };
-    ret;
+let make =
+    (
+      ~onMouseDown: mouseButtonHandler=eventNoop,
+      ~onMouseMove: mouseMoveHandler=eventNoop,
+      ~onMouseUp: mouseButtonHandler=eventNoop,
+      _unit: unit,
+    ) => {
+  let ret: t = {onMouseDown, onMouseMove, onMouseUp};
+  ret;
 };
 
-let default = make(());
+let default = make();

--- a/src/UI/NodeEvents.re
+++ b/src/UI/NodeEvents.re
@@ -5,34 +5,35 @@
 type eventResult =
 | Continue;
 
-type commonMouseEvent = {
-    xPos: float,   
-    yPos: float,
+type mouseMoveEventParams = {
+    mouseX: float,   
+    mouseY: float,
 };
 
-type mouseDownEvent = commonMouseEvent;
-type mouseMoveEvent = commonMouseEvent;
+type mouseButtonEventParams = mouseMoveEventParams;
 
 type mouseEvent = 
-| MouseDown(commonMouseEvent)
-| MouseMove(commonMouseEvent)
-| MouseUp(commonMouseEvent)
+| MouseDown(mouseButtonEventParams)
+| MouseMove(mouseMoveEventParams)
+| MouseUp(mouseButtonEventParams)
 
 
-type mouseDownHandler = (mouseDownEvent) => eventResult;
-type mouseMoveHandler = (mouseDownEvent) => eventResult;
+type mouseButtonHandler = (mouseButtonEventParams) => eventResult;
+type mouseMoveHandler = (mouseMoveEventParams) => eventResult;
 
 type t = {
-    onMouseDown: mouseDownHandler,
+    onMouseDown: mouseButtonHandler,
     onMouseMove: mouseMoveHandler,
+    onMouseUp: mouseButtonHandler,
 };
 
 let eventNoop = (_evt) => Continue;
 
-let make = (~onMouseDown: mouseDownHandler=eventNoop,~onMouseMove:mouseMoveHandler=eventNoop, _unit: unit) => {
+let make = (~onMouseDown: mouseButtonHandler=eventNoop,~onMouseMove:mouseMoveHandler=eventNoop, ~onMouseUp:mouseButtonHandler=eventNoop, _unit: unit) => {
     let ret: t = {
         onMouseDown,
         onMouseMove,
+        onMouseUp,
     };
     ret;
 };

--- a/src/UI/NodeEvents.re
+++ b/src/UI/NodeEvents.re
@@ -4,9 +4,6 @@
 
 open Revery_Core;
 
-type eventResult =
-| Continue;
-
 type mouseMoveEventParams = {
     mouseX: float,
     mouseY: float,
@@ -23,8 +20,8 @@ type mouseEvent =
 | MouseMove(mouseMoveEventParams)
 | MouseUp(mouseButtonEventParams);
 
-type mouseButtonHandler = (mouseButtonEventParams) => eventResult;
-type mouseMoveHandler = (mouseMoveEventParams) => eventResult;
+type mouseButtonHandler = (mouseButtonEventParams) => unit;
+type mouseMoveHandler = (mouseMoveEventParams) => unit;
 
 type t = {
     onMouseDown: mouseButtonHandler,
@@ -32,7 +29,7 @@ type t = {
     onMouseUp: mouseButtonHandler,
 };
 
-let eventNoop = (_evt) => Continue;
+let eventNoop = (_evt) => ();
 
 let make = (~onMouseDown: mouseButtonHandler=eventNoop,~onMouseMove:mouseMoveHandler=eventNoop, ~onMouseUp:mouseButtonHandler=eventNoop, _unit: unit) => {
     let ret: t = {

--- a/src/UI/NodeEvents.re
+++ b/src/UI/NodeEvents.re
@@ -1,0 +1,40 @@
+/* NodeEvents.re */
+
+/* A collection of event handlers to be used by the Nodes */
+
+type eventResult =
+| Continue;
+
+type commonMouseEvent = {
+    xPos: float,   
+    yPos: float,
+};
+
+type mouseDownEvent = commonMouseEvent;
+type mouseMoveEvent = commonMouseEvent;
+
+type mouseEvent = 
+| MouseDown(commonMouseEvent)
+| MouseMove(commonMouseEvent)
+| MouseUp(commonMouseEvent)
+
+
+type mouseDownHandler = (mouseDownEvent) => eventResult;
+type mouseMoveHandler = (mouseDownEvent) => eventResult;
+
+type t = {
+    onMouseDown: mouseDownHandler,
+    onMouseMove: mouseMoveHandler,
+};
+
+let eventNoop = (_evt) => Continue;
+
+let make = (~onMouseDown: mouseDownHandler=eventNoop,~onMouseMove:mouseMoveHandler=eventNoop, _unit: unit) => {
+    let ret: t = {
+        onMouseDown,
+        onMouseMove,
+    };
+    ret;
+};
+
+let default = make(());

--- a/src/UI/Primitives.re
+++ b/src/UI/Primitives.re
@@ -1,0 +1,19 @@
+/*
+ * Primitives
+ * 
+ * These are the 'raw primitives' that our API describes.
+ * These map directly to the raw nodes that get emitted in our scene graph.
+ *
+ * More details here:
+ * https://github.com/bryphe/reason-reactify
+ */
+
+let view = (~children, ~style=Style.defaultStyle, ~onMouseDown=NodeEvents.eventNoop, ~onMouseUp=NodeEvents.eventNoop, ~onMouseMove=NodeEvents.eventNoop, ()) =>
+  UiReact.primitiveComponent(View(style, NodeEvents.make(~onMouseDown, ~onMouseMove, ~onMouseUp, ())), ~children);
+
+let image = (~children, ~style=Style.defaultStyle, ~src="", ()) =>
+  UiReact.primitiveComponent(Image(style, src), ~children);
+
+let text = (~children: list(string), ~style=Style.defaultStyle, ()) =>
+  UiReact.primitiveComponent(Text(style, List.hd(children)), ~children=[]);
+

--- a/src/UI/Primitives.re
+++ b/src/UI/Primitives.re
@@ -1,6 +1,6 @@
 /*
  * Primitives
- * 
+ *
  * These are the 'raw primitives' that our API describes.
  * These map directly to the raw nodes that get emitted in our scene graph.
  *
@@ -8,12 +8,22 @@
  * https://github.com/bryphe/reason-reactify
  */
 
-let view = (~children, ~style=Style.defaultStyle, ~onMouseDown=NodeEvents.eventNoop, ~onMouseUp=NodeEvents.eventNoop, ~onMouseMove=NodeEvents.eventNoop, ()) =>
-  UiReact.primitiveComponent(View(style, NodeEvents.make(~onMouseDown, ~onMouseMove, ~onMouseUp, ())), ~children);
+let view =
+    (
+      ~children,
+      ~style=Style.defaultStyle,
+      ~onMouseDown=NodeEvents.eventNoop,
+      ~onMouseUp=NodeEvents.eventNoop,
+      ~onMouseMove=NodeEvents.eventNoop,
+      (),
+    ) =>
+  UiReact.primitiveComponent(
+    View(style, NodeEvents.make(~onMouseDown, ~onMouseMove, ~onMouseUp, ())),
+    ~children,
+  );
 
 let image = (~children, ~style=Style.defaultStyle, ~src="", ()) =>
   UiReact.primitiveComponent(Image(style, src), ~children);
 
 let text = (~children: list(string), ~style=Style.defaultStyle, ()) =>
   UiReact.primitiveComponent(Text(style, List.hd(children)), ~children=[]);
-

--- a/src/UI/Revery_UI.re
+++ b/src/UI/Revery_UI.re
@@ -27,8 +27,8 @@ class imageNode = class ImageNode.imageNode;
 open UiReconciler;
 let component = UiReact.component;
 
-let view = (~children, ~style=Style.defaultStyle, ()) =>
-  UiReact.primitiveComponent(View(style), ~children);
+let view = (~children, ~style=Style.defaultStyle, ~onMouseDown=NodeEvents.eventNoop, ()) =>
+  UiReact.primitiveComponent(View(style, NodeEvents.make(~onMouseDown, ())), ~children);
 
 let image = (~children, ~style=Style.defaultStyle, ~src="", ()) =>
   UiReact.primitiveComponent(Image(style, src), ~children);

--- a/src/UI/Revery_UI.re
+++ b/src/UI/Revery_UI.re
@@ -120,22 +120,44 @@ let start =
   let rootNode = (new viewNode)();
   let container = UiReact.createContainer(rootNode);
   let mouseCursor: Mouse.Cursor.t = Mouse.Cursor.make();
-  let ui: uiContainer = {window, rootNode, container, mouseCursor, options: createOptions};
+  let ui: uiContainer = {
+    window,
+    rootNode,
+    container,
+    mouseCursor,
+    options: createOptions,
+  };
 
-  let _ = Revery_Core.Event.subscribe(window.onMouseMove, (m) => {
-    let evt =  Revery_Core.Events.InternalMouseMove({ mouseX: m.mouseX, mouseY: m.mouseY });
-    Mouse.dispatch(mouseCursor, evt, rootNode);
-  });
+  let _ =
+    Revery_Core.Event.subscribe(
+      window.onMouseMove,
+      m => {
+        let evt =
+          Revery_Core.Events.InternalMouseMove({
+            mouseX: m.mouseX,
+            mouseY: m.mouseY,
+          });
+        Mouse.dispatch(mouseCursor, evt, rootNode);
+      },
+    );
 
-  let _ = Revery_Core.Event.subscribe(window.onMouseDown, (m) => {
-    let evt = Revery_Core.Events.InternalMouseDown({button: m.button}); 
-    Mouse.dispatch(mouseCursor, evt, rootNode);
-  });
+  let _ =
+    Revery_Core.Event.subscribe(
+      window.onMouseDown,
+      m => {
+        let evt = Revery_Core.Events.InternalMouseDown({button: m.button});
+        Mouse.dispatch(mouseCursor, evt, rootNode);
+      },
+    );
 
-  let _ = Revery_Core.Event.subscribe(window.onMouseUp, (m) => {
-    let evt = Revery_Core.Events.InternalMouseUp({button: m.button}); 
-    Mouse.dispatch(mouseCursor, evt, rootNode);
-  });
+  let _ =
+    Revery_Core.Event.subscribe(
+      window.onMouseUp,
+      m => {
+        let evt = Revery_Core.Events.InternalMouseUp({button: m.button});
+        Mouse.dispatch(mouseCursor, evt, rootNode);
+      },
+    );
 
   Window.setShouldRenderCallback(window, () => Animated.anyActiveAnimations());
   Window.setRenderCallback(

--- a/src/UI/Revery_UI.re
+++ b/src/UI/Revery_UI.re
@@ -22,23 +22,16 @@ let useReducer = UiReact.useReducer;
 
 open RenderPass;
 
-/* class node = class Node.node(RenderPass.t); */
+class node = class Node.node(RenderPass.t);
 class viewNode = class ViewNode.viewNode;
 class textNode = class TextNode.textNode;
 class imageNode = class ImageNode.imageNode;
 
+module Mouse = Mouse;
 module NodeEvents = NodeEvents;
-open UiReconciler;
 let component = UiReact.component;
 
-let view = (~children, ~style=Style.defaultStyle, ~onMouseDown=NodeEvents.eventNoop, ~onMouseUp=NodeEvents.eventNoop, ~onMouseMove=NodeEvents.eventNoop, ()) =>
-  UiReact.primitiveComponent(View(style, NodeEvents.make(~onMouseDown, ~onMouseMove, ~onMouseUp, ())), ~children);
-
-let image = (~children, ~style=Style.defaultStyle, ~src="", ()) =>
-  UiReact.primitiveComponent(Image(style, src), ~children);
-
-let text = (~children: list(string), ~style=Style.defaultStyle, ()) =>
-  UiReact.primitiveComponent(Text(style, List.hd(children)), ~children=[]);
+include Primitives;
 
 type uiContainerOptions = {autoSize: bool};
 

--- a/src/UI/Revery_UI.re
+++ b/src/UI/Revery_UI.re
@@ -17,9 +17,12 @@ module Transform = Transform;
 /* Expose hooks as part of the public API */
 include Hooks;
 
+let useState = UiReact.useState;
+let useReducer = UiReact.useReducer;
+
 open RenderPass;
 
-class node = class Node.node(RenderPass.t);
+/* class node = class Node.node(RenderPass.t); */
 class viewNode = class ViewNode.viewNode;
 class textNode = class TextNode.textNode;
 class imageNode = class ImageNode.imageNode;
@@ -127,8 +130,18 @@ let start =
   let ui: uiContainer = {window, rootNode, container, mouseCursor, options: createOptions};
 
   let _ = Revery_Core.Event.subscribe(window.onMouseMove, (m) => {
-    let evt: NodeEvents.mouseMoveEventParams =  { mouseX: m.mouseX, mouseY: m.mouseY };
-    Mouse.dispatch(mouseCursor,  NodeEvents.MouseMove(evt), rootNode);
+    let evt =  Revery_Core.Events.InternalMouseMove({ mouseX: m.mouseX, mouseY: m.mouseY });
+    Mouse.dispatch(mouseCursor, evt, rootNode);
+  });
+
+  let _ = Revery_Core.Event.subscribe(window.onMouseDown, (m) => {
+    let evt = Revery_Core.Events.InternalMouseDown({button: m.button}); 
+    Mouse.dispatch(mouseCursor, evt, rootNode);
+  });
+
+  let _ = Revery_Core.Event.subscribe(window.onMouseUp, (m) => {
+    let evt = Revery_Core.Events.InternalMouseUp({button: m.button}); 
+    Mouse.dispatch(mouseCursor, evt, rootNode);
   });
 
   Window.setShouldRenderCallback(window, () => Animated.anyActiveAnimations());

--- a/src/UI/UiReconciler.re
+++ b/src/UI/UiReconciler.re
@@ -13,6 +13,7 @@ type primitives =
 type node = Node.node(renderPass);
 
 let createInstance = prim => {
+    print_endline ("createInstance");
   let node =
     switch (prim) {
     | View(style, events) =>

--- a/src/UI/UiReconciler.re
+++ b/src/UI/UiReconciler.re
@@ -6,7 +6,7 @@
 open RenderPass;
 
 type primitives =
-  | View(Style.t)
+  | View(Style.t, NodeEvents.t)
   | Text(Style.t, string)
   | Image(Style.t, string);
 
@@ -15,9 +15,10 @@ type node = Node.node(renderPass);
 let createInstance = prim => {
   let node =
     switch (prim) {
-    | View(style) =>
+    | View(style, events) =>
       let view = (new ViewNode.viewNode)();
       view#setStyle(style);
+      view#setEvents(events);
       view;
     | Image(style, src) =>
       let img = (new ImageNode.imageNode)(src);
@@ -34,10 +35,11 @@ let createInstance = prim => {
 
 let updateInstance = (n: node, _oldPrim: primitives, newPrim: primitives) =>
   switch (newPrim) {
-  | View(style) =>
+  | View(style, events) =>
     /* TODO: Is there a way to downcast properly here, from Node -> ViewNode ? */
     let vn: ViewNode.viewNode = Obj.magic(n);
     vn#setStyle(style);
+    vn#setEvents(events);
   | Text(style, text) =>
     /* TODO: Is there a way to downcast properly here, from Node -> TextNode ? */
     let tn: TextNode.textNode = Obj.magic(n);

--- a/src/UI/UiReconciler.re
+++ b/src/UI/UiReconciler.re
@@ -13,7 +13,6 @@ type primitives =
 type node = Node.node(renderPass);
 
 let createInstance = prim => {
-    print_endline ("createInstance");
   let node =
     switch (prim) {
     | View(style, events) =>

--- a/test/UI/MouseTest.re
+++ b/test/UI/MouseTest.re
@@ -1,0 +1,42 @@
+open Rejest;
+
+open Revery_UI;
+
+let createNodeWithStyle = (style) => {
+  let node = (new node)();
+  node#setStyle(style);
+  Layout.layout(node, 1);
+  node;
+}
+
+test("Mouse", () => {
+  test("dispatch", () => {
+    test("triggers onMouseDown event for node", () => {
+
+      let cursor = Mouse.Cursor.make();
+
+      let count = ref(0);
+      let f = (_evt) => count := count^ + 1;
+      let node = createNodeWithStyle(Style.make(~width=100, ~height=100, ()));
+      node#setEvents(NodeEvents.make(~onMouseDown=f, ()));  
+
+      Mouse.dispatch(cursor, InternalMouseMove({mouseX: 50., mouseY: 50. }), node);
+      Mouse.dispatch(cursor, InternalMouseDown({button: BUTTON_LEFT}), node);
+
+      expect(count^).toBe(1);
+    });
+    test("does not trigger onMouseUp event for node if outside node", () => {
+      let cursor = Mouse.Cursor.make();
+
+      let count = ref(0);
+      let f = (_evt) => count := count^ + 1;
+      let node = createNodeWithStyle(Style.make(~width=100, ~height=100, ()));
+      node#setEvents(NodeEvents.make(~onMouseDown=f, ()));  
+
+      Mouse.dispatch(cursor, InternalMouseMove({mouseX: 150., mouseY: 150. }), node);
+      Mouse.dispatch(cursor, InternalMouseUp({button: BUTTON_LEFT}), node);
+
+      expect(count^).toBe(0);
+    });
+  });
+});

--- a/test/UI/MouseTest.re
+++ b/test/UI/MouseTest.re
@@ -2,25 +2,29 @@ open Rejest;
 
 open Revery_UI;
 
-let createNodeWithStyle = (style) => {
+let createNodeWithStyle = style => {
   let node = (new node)();
   node#setStyle(style);
   Layout.layout(node, 1);
   node;
-}
+};
 
-test("Mouse", () => {
+test("Mouse", () =>
   test("dispatch", () => {
     test("triggers onMouseDown event for node", () => {
-
       let cursor = Mouse.Cursor.make();
 
       let count = ref(0);
-      let f = (_evt) => count := count^ + 1;
-      let node = createNodeWithStyle(Style.make(~width=100, ~height=100, ()));
-      node#setEvents(NodeEvents.make(~onMouseDown=f, ()));  
+      let f = _evt => count := count^ + 1;
+      let node =
+        createNodeWithStyle(Style.make(~width=100, ~height=100, ()));
+      node#setEvents(NodeEvents.make(~onMouseDown=f, ()));
 
-      Mouse.dispatch(cursor, InternalMouseMove({mouseX: 50., mouseY: 50. }), node);
+      Mouse.dispatch(
+        cursor,
+        InternalMouseMove({mouseX: 50., mouseY: 50.}),
+        node,
+      );
       Mouse.dispatch(cursor, InternalMouseDown({button: BUTTON_LEFT}), node);
 
       expect(count^).toBe(1);
@@ -29,14 +33,19 @@ test("Mouse", () => {
       let cursor = Mouse.Cursor.make();
 
       let count = ref(0);
-      let f = (_evt) => count := count^ + 1;
-      let node = createNodeWithStyle(Style.make(~width=100, ~height=100, ()));
-      node#setEvents(NodeEvents.make(~onMouseDown=f, ()));  
+      let f = _evt => count := count^ + 1;
+      let node =
+        createNodeWithStyle(Style.make(~width=100, ~height=100, ()));
+      node#setEvents(NodeEvents.make(~onMouseDown=f, ()));
 
-      Mouse.dispatch(cursor, InternalMouseMove({mouseX: 150., mouseY: 150. }), node);
+      Mouse.dispatch(
+        cursor,
+        InternalMouseMove({mouseX: 150., mouseY: 150.}),
+        node,
+      );
       Mouse.dispatch(cursor, InternalMouseUp({button: BUTTON_LEFT}), node);
 
       expect(count^).toBe(0);
     });
-  });
-});
+  })
+);


### PR DESCRIPTION
This wires up the GLFW mouse events to the hit testing that was implemented in #87 , and exposes them in our `<view />` primitive.

This is a stepping stone, but gets us closer to having first-class `<Button />`, `<Slider />`, `<Scrollbar />` components.

__TODO:__
- [ ] Remove debug printing
- [ ] Add some initial test cases to show how we can unit-test the event / node interface