### PR TITLE
Bugfix: Fix issue where maximizing / resizing window breaks rendering

### DIFF
--- a/src/Core/Window.re
+++ b/src/Core/Window.re
@@ -161,6 +161,15 @@ let create = (name: string, options: windowCreateOptions) => {
   Glfw.glfwSetFramebufferSizeCallback(
     w,
     (_w, width, height) => {
+      ret.framebufferWidth = width;
+      ret.framebufferHeight = height;
+      render(ret);
+    },
+  );
+
+  Glfw.glfwSetWindowSizeCallback(
+    w,
+    (_w, width, height) => {
       ret.width = width;
       ret.height = height;
       render(ret);


### PR DESCRIPTION
__Issue:__ Maximizing (or even just resizing) the window completely breaks rendering - this is easy to see with the `Bin.exe` example - if you maximize or resize, you'll just get an empty screen.

__Defect:__ We weren't properly setting width/height/framebufferWidth/framebufferHeight in the callbacks.

__Fix:__
- For the `glfwSetFramebufferSizeCallback`, we set the `framebufferWidth/framebufferHeight` properties
- For the `glfwSetWindowSizeCallback`, set the `width/height` properties

This is an important distinction, because the window size is not always at a 1-to-1 ratio with the framebuffer size (for example, high-dpi displays).