### PR TITLE
[DOC] Add information for mac users

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ npm install -g esy
 
 #### For `macOS` users
 
-If your build takes to much time then is better to pre install some libraries:
+If your build takes too much time then you can pre-install some libraries:
 
 - `brew install cmake`
 - `brew install libpng ragel`

--- a/README.md
+++ b/README.md
@@ -19,6 +19,13 @@ npm install -g esy
 - `esy install`
 - `esy build`
 
+#### For `macOS` users
+
+If your build takes to much time then is better to pre install some libraries:
+
+- `brew install cmake`
+- `brew install libpng ragel`
+
 ### Running
 
 After you build, the executables will be available in the `_build\install\default\bin` folder.
@@ -26,7 +33,7 @@ After you build, the executables will be available in the `_build\install\defaul
 > NOTE: Currently the executables must be run from `install\default\bin`, since the assets are there.
 
 To run the example app, you can do:
-- `cd _build/install/default/bin`
+- `cd _build/default/examples/`
 - `./Bin.exe`
 
 ### Tests


### PR DESCRIPTION
I was tried to run examples from this repository yesterday. I faced the problem with running it on my `macOS` (endless build step :D). 
I solved this by preinstalling some libs. Big thanks to @bryphe and @ulrikstrid for help.

The second problem was with a path for built examples.