### PR TITLE
Treat mouse events as optional

### DIFF
--- a/src/UI/Node.re
+++ b/src/UI/Node.re
@@ -80,10 +80,13 @@ class node ('a) (()) = {
   pub getMeasureFunction = (_pixelRatio: int) => None;
   pub handleEvent = (evt: NodeEvents.mouseEvent) => {
     let _ =
-      switch (evt) {
-      | MouseDown(c) => _this#getEvents().onMouseDown(c)
-      | MouseMove(c) => _this#getEvents().onMouseMove(c)
-      | MouseUp(c) => _this#getEvents().onMouseUp(c)
+      switch (evt, _this#getEvents()) {
+      | (MouseDown(c), {onMouseDown: Some(cb), _}) => cb(c)
+      | (MouseMove(c), {onMouseMove: Some(cb), _}) => cb(c)
+      | (MouseUp(c), {onMouseUp: Some(cb), _}) => cb(c)
+      | (MouseDown(_), _)
+      | (MouseMove(_), _)
+      | (MouseUp(_), _) => ()
       };
     ();
   };

--- a/src/UI/NodeEvents.re
+++ b/src/UI/NodeEvents.re
@@ -24,20 +24,12 @@ type mouseButtonHandler = mouseButtonEventParams => unit;
 type mouseMoveHandler = mouseMoveEventParams => unit;
 
 type t = {
-  onMouseDown: mouseButtonHandler,
-  onMouseMove: mouseMoveHandler,
-  onMouseUp: mouseButtonHandler,
+  onMouseDown: option(mouseButtonHandler),
+  onMouseMove: option(mouseMoveHandler),
+  onMouseUp: option(mouseButtonHandler),
 };
 
-let eventNoop = _evt => ();
-
-let make =
-    (
-      ~onMouseDown: mouseButtonHandler=eventNoop,
-      ~onMouseMove: mouseMoveHandler=eventNoop,
-      ~onMouseUp: mouseButtonHandler=eventNoop,
-      _unit: unit,
-    ) => {
+let make = (~onMouseDown=?, ~onMouseMove=?, ~onMouseUp=?, _unit: unit) => {
   let ret: t = {onMouseDown, onMouseMove, onMouseUp};
   ret;
 };

--- a/src/UI/Primitives.re
+++ b/src/UI/Primitives.re
@@ -10,15 +10,18 @@
 
 let view =
     (
+      ~onMouseDown=?,
+      ~onMouseMove=?,
+      ~onMouseUp=?,
       ~children,
       ~style=Style.defaultStyle,
-      ~onMouseDown=NodeEvents.eventNoop,
-      ~onMouseUp=NodeEvents.eventNoop,
-      ~onMouseMove=NodeEvents.eventNoop,
       (),
     ) =>
   UiReact.primitiveComponent(
-    View(style, NodeEvents.make(~onMouseDown, ~onMouseMove, ~onMouseUp, ())),
+    View(
+      style,
+      NodeEvents.make(~onMouseDown?, ~onMouseMove?, ~onMouseUp?, ()),
+    ),
     ~children,
   );
 


### PR DESCRIPTION
Small enhancement that leverages the language + JSX transform to make the `onMouse*` props really optional. This allows to remove the noop from `NodeEvents` but more importantly it avoids to perform all those noop calls for elements that don't set any event listeners, which removes some overhead (not sure really how much impact it would have in performance, but every little step counts! 😄 ).

From the users / API perspective, nothing changes (i.e. they can still pass raw callbacks to `onMouse*` props without the need to wrap these callbacks with `Some`).