### PR TITLE
Fix url to Inria

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,7 +230,7 @@ Some ideas for getting started:
 ## Special Thanks
 
 `revery` would not be possible without a bunch of cool tech:
-- [ocaml](https://ocaml.org) made these tools possible - thanks [Inria](https://caml.inria.fr) & [OCaml Labs](http://ocamllabs.io/)!
+- [ocaml](https://ocaml.org) made these tools possible - thanks [Inria](http://gallium.inria.fr/) & [OCaml Labs](http://ocamllabs.io/)!
 - [reasonml](https://reasonml.github.io) made revery possible - thanks @jordwalke!
 - [flex](https://github.com/jordwalke/flex) by @jordwalke
 - [briskml](https://github.com/briskml)


### PR DESCRIPTION
caml.inria.fr is deprecated and superseded by ocaml.org. I updated to the Gallium team's page at Inria. That is the team that Xavier Leroy is the head of, and thus the team that is in charge of OCaml.