### PR TITLE
Fix #514

### DIFF
--- a/src/UI_Components/ScrollView.re
+++ b/src/UI_Components/ScrollView.re
@@ -38,6 +38,8 @@ let make =
       children: React.syntheticElement,
     ) =>
   component(slots => {
+    let (dummy, setDummy, slots) = Hooks.state(0, slots);
+
     let (actualScrollTop, dispatch, slots) =
       Hooks.reducer(~initialState=scrollTop, reducer, slots);
     let (outerRef: option(Revery_UI.node), setOuterRef, slots) =
@@ -52,6 +54,17 @@ let make =
       TranslateX((-1.) *. float_of_int(actualScrollLeft)),
       TranslateY((-1.) *. float_of_int(actualScrollTop)),
     ];
+
+    let slots =
+      Hooks.effect(
+        Revery_UI.React.Hooks.Effect.If((!==), children),
+        () => {
+          setDummy(dummy + 1);
+
+          None;
+        },
+        slots,
+      );
 
     let (horizontalScrollBar, verticalScrollBar, scroll) =
       switch (outerRef) {


### PR DESCRIPTION
force rerender in scrollview on children update (which is everytime I suppose if brisk treats props immutable)

I was tinkering with onivim2 and noticed this #514 .

That is my first time with brisk, so it is just a though experiment. The container view updates perfectly since its height is managed by the reconciliation. As I understand the code, we acquire the ref, to measure the the height and than pass it to the vertical sidebar. This is where things get out of sync.

Since the container view is not re-mounted, the callback with the `ref `and then setState does not fire.

When we scroll however, we trigger a re-render and the height is recalculated.

The thing I don't get is the `ref` should be just a memory reference to the container object. So we should have the most up to date value on the ref all the time. But that is not the case. This dirty approach solves the problem, by forcing a re-render, but looking at the code it should take care of itself. 

What do you guys think?